### PR TITLE
Don't run no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -26,7 +26,7 @@ jobs:
         run: uv python install
 
       - name: Run checks
-        run: uv run pre-commit run --all-files --show-diff-on-failure
+        run: uv run pre-commit run --all-files --hook-stage push --show-diff-on-failure
 
   run-tests:
     name: Run tests (Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
         args: [--branch, main]
+        stages: [commit]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0


### PR DESCRIPTION
This pull request updates the pre-commit configuration and workflow to clarify when certain checks run and to improve the reliability of pre-commit hooks. The most important changes are grouped below:

**Pre-commit configuration improvements:**

* The `no-commit-to-branch` hook in `.pre-commit-config.yaml` is now explicitly set to run only at the `commit` stage, preventing it from interfering with other hook stages.

**Workflow execution changes:**

* The GitHub Actions workflow in `.github/workflows/run-checks.yaml` now runs pre-commit checks at the `push` hook stage, ensuring that checks are performed on code as it is pushed, not just on commit.