### PR TITLE
fix: replace heredoc with python inline for completion json parsing

### DIFF
--- a/src/gmuse/templates/zsh_completion.zsh
+++ b/src/gmuse/templates/zsh_completion.zsh
@@ -85,12 +85,15 @@ _gmuse_git_commit_message() {
 
         # Parse JSON output using python3 (avoiding jq dependency and handling escaped quotes)
         local parsed_json
-        parsed_json=$(printf '%s\n' "$json_output" | python3 -c 'import sys, json; ' \
-            'data = json.load(sys.stdin); ' \
-            'status = str(data.get("status", "") or ""); ' \
-            'suggestion = str(data.get("suggestion", "") or ""); ' \
-            'suggestion = suggestion.replace("\r\n", " ").replace("\n", " ").replace("\r", " "); ' \
-            'sys.stdout.write(f"{status}\x1f{suggestion}")' 2>/dev/null || true)
+        parsed_json=$(printf '%s\n' "$json_output" | python3 -c 'import sys, json
+try:
+    data = json.load(sys.stdin)
+    status = str(data.get("status", "") or "")
+    suggestion = str(data.get("suggestion", "") or "")
+    suggestion = suggestion.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    sys.stdout.write(f"{status}\x1f{suggestion}")
+except Exception:
+    pass' 2>/dev/null || true)
         gmuse_status=${parsed_json%%$'\x1f'*}
         suggestion=${parsed_json#*$'\x1f'}
         # Handle non-ok statuses


### PR DESCRIPTION
The issue was that the heredoc syntax (python3 - <<'EOF') doesn't work correctly inside command substitution when combined with a pipe in zsh. The heredoc gets ignored and the JSON gets sent directly to python3 -, which tries to execute it as Python code.