### PR TITLE
feat: log prompts and suggestion output when debug mode is turned on

### DIFF
--- a/src/gmuse/llm.py
+++ b/src/gmuse/llm.py
@@ -257,6 +257,8 @@ class LLMClient:
             'Hello! How can I help you today?'
         """
         logger.debug(f"Generating with model={self.model}, temperature={temperature}")
+        logger.debug(f"System prompt:\n{system_prompt}")
+        logger.debug(f"User prompt:\n{user_prompt}")
 
         messages = [
             {"role": "system", "content": system_prompt},
@@ -279,7 +281,7 @@ class LLMClient:
             if not content:
                 raise LLMError("LLM returned empty response")
 
-            logger.debug(f"Generated {len(content)} characters")
+            logger.debug(f"Generated text: {content.strip()}")
             return content.strip()
 
         except LLMError:


### PR DESCRIPTION
This pull request adds more detailed logging to the `generate` method in `src/gmuse/llm.py` to help with debugging prompt and response content. The main changes include logging the actual system and user prompts as well as the generated output text.

Logging improvements:

* Added debug logs to output the full `system_prompt` and `user_prompt` before sending them to the language model.
* Changed the log message after text generation to show the actual generated text instead of just its length.