### PR TITLE
Add local model docs and Ollama provider detection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -204,7 +204,7 @@
         "filename": "src/gmuse/llm.py",
         "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 137
       }
     ],
     "tests/integration/test_cli.py": [
@@ -240,5 +240,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-23T20:00:18Z"
+  "generated_at": "2026-05-23T02:45:18Z"
 }

--- a/docs/source/how_to/configuration.md
+++ b/docs/source/how_to/configuration.md
@@ -65,6 +65,8 @@ $ export GEMINI_API_KEY="..."
 $ gmuse msg --model <model-name>
 ```
 
+For local models such as Ollama, see [Host a local model](local_models.md).
+
 To set your default model, add it to your config file:
 ```toml
 model = "claude-3-5-sonnet-20241022"

--- a/docs/source/how_to/index.md
+++ b/docs/source/how_to/index.md
@@ -40,6 +40,15 @@ Enable context-aware AI completions in your favorite shell.
 Common errors, diagnostics, and debugging tips.
 :::
 ::::
+
+::::{grid-item}
+:::{card} {octicon}`shield-lock;1.2em;sd-text-primary` Local Models
+:link: local_models
+:link-type: doc
+
+Run a local LLM for maximum privacy.
+:::
+::::
 :::::
 
 ```{toctree}
@@ -50,4 +59,5 @@ installation
 configuration
 completions
 troubleshooting
+local_models
 ```

--- a/docs/source/how_to/local_models.md
+++ b/docs/source/how_to/local_models.md
@@ -1,0 +1,176 @@
+# Host a local model (maximum privacy)
+
+This guide shows how to run `gmuse` against a **local** LLM so your prompts and responses stay on your machine.
+
+- `gmuse` uses [LiteLLM](https://docs.litellm.ai/docs/) under the hood.
+- Local hosting means **you** operate the model runtime (no gmuse backend servers).
+
+If you haven't already, read the privacy overview: [Privacy & Security](../explanation/privacy.md).
+
+## When to use a local model
+
+Local hosting is a good fit when you want:
+
+- Maximum privacy (no third-party API calls)
+- Offline usage (after the model is downloaded)
+- Predictable costs (no per-request billing)
+
+It may be a poor fit when you need:
+
+- The highest quality for complex reasoning (local models may be weaker than frontier hosted models)
+- Very large context windows
+- Zero maintenance (you are responsible for updates and security)
+
+## Security checklist (read first)
+
+If you follow only one section, follow this one.
+
+- **Bind locally by default**: keep the inference server on `127.0.0.1` (localhost).
+- **Do not expose the port publicly** unless you understand the risks.
+- **If you must access it remotely**:
+  - Put it behind authentication.
+  - Use TLS.
+  - Restrict access (VPN, firewall rules, allowlists).
+- **Disable debug logging** in sensitive environments:
+  - Avoid `GMUSE_DEBUG=1` and DEBUG-level logs because prompts/diffs may be written to logs.
+- **Treat model downloads like binaries**:
+  - Prefer official sources.
+  - Keep the runtime and models updated.
+  - Review licensing before redistribution or commercial use.
+
+## Recommended “golden path”: Ollama + LiteLLM
+
+Ollama is a simple local LLM runtime. LiteLLM supports Ollama models via the `ollama/` (or `ollama_chat/`) model prefix.
+
+### 1) Install and run Ollama
+
+Follow Ollama’s official install instructions for your OS:
+
+- https://ollama.com/download
+
+Ensure the Ollama server is running and listening on localhost (default: `http://localhost:11434`).
+
+### 2) Pull a model
+
+Pick a model that’s strong at short, structured text generation.
+
+Examples (choose one):
+
+```console
+$ ollama pull qwen2.5-coder
+```
+
+```console
+$ ollama pull llama3.1
+```
+
+Notes:
+
+- Smaller models (around 7B–8B) are typically a good speed/quality balance for commit messages.
+- Model names vary by runtime; use `ollama list` to see what you have locally.
+
+### 3) Point gmuse at the local model
+
+You can configure a local model either temporarily (environment) or persistently (config file).
+
+**Option A — Environment variable (one shell session):**
+
+```console
+$ export GMUSE_MODEL="ollama/qwen2.5-coder"
+$ gmuse msg
+```
+
+**Option B — Config file (persistent):**
+
+Add to `~/.config/gmuse/config.toml`:
+
+```toml
+model = "ollama/qwen2.5-coder"
+```
+
+Then run:
+
+```console
+$ gmuse msg
+```
+
+### 4) Verify configuration
+
+`gmuse info` prints the resolved model and provider heuristics:
+
+```console
+$ gmuse info
+```
+
+If your provider is detected as `ollama`, your `GMUSE_MODEL` is being interpreted as a local runtime model.
+
+## Generalize to other local backends
+
+Ollama is the simplest path, but it’s not the only one.
+
+Two common patterns work well with `gmuse`:
+
+### Pattern A — Use a LiteLLM provider prefix
+
+If LiteLLM supports your local backend directly, set `GMUSE_MODEL` to the appropriate provider-prefixed model name.
+
+Examples:
+
+- `ollama/<model>`
+- `ollama_chat/<model>` (often better chat-style responses)
+
+See the LiteLLM providers list:
+
+- https://docs.litellm.ai/docs/providers
+
+### Pattern B — Use an OpenAI-compatible endpoint (advanced)
+
+Some local servers expose an OpenAI-compatible API.
+
+Best practices for this approach:
+
+- Prefer a LiteLLM provider that matches your backend (when available) instead of the generic OpenAI-compatible route.
+- If your OpenAI-compatible client requires an API key even locally, use a non-sensitive placeholder and enable authentication on the server if it’s reachable beyond localhost.
+
+LiteLLM reference:
+
+- https://docs.litellm.ai/docs/providers/openai_compatible
+
+## Troubleshooting
+
+### gmuse says no provider is configured
+
+Run:
+
+```console
+$ gmuse info
+```
+
+Common causes:
+
+- `GMUSE_MODEL` isn’t set and no provider API key env var is set.
+- `GMUSE_MODEL` is set to a value LiteLLM doesn’t recognize.
+
+### Connection errors
+
+If you see errors connecting to Ollama:
+
+- Verify the server is running (default address `http://localhost:11434`).
+- Confirm the model exists locally: `ollama list`.
+- Ensure you can reach the server from the same environment you run `gmuse` from.
+
+### Output is too long or too random
+
+Tune these settings:
+
+- Lower temperature for more deterministic messages
+- Reduce max tokens for shorter outputs
+
+Example config:
+
+```toml
+temperature = 0.2
+max_tokens = 200
+```
+
+See also: [Configure gmuse](configuration.md) and the [Configuration Reference](../reference/configuration.md).

--- a/src/gmuse/llm.py
+++ b/src/gmuse/llm.py
@@ -117,9 +117,17 @@ def detect_provider() -> Optional[str]:
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         return "gemini"
 
-    # Check if GMUSE_MODEL explicitly indicates gemini
+    # Check if GMUSE_MODEL explicitly indicates a provider that does not
+    # require an API key (e.g., local runtimes).
     if model := os.getenv("GMUSE_MODEL"):
-        if model.lower().startswith("gemini/") or "gemini" in model.lower():
+        lowered = model.lower()
+
+        # Local runtimes via LiteLLM (no API key required)
+        if lowered.startswith("ollama/") or lowered.startswith("ollama_chat/"):
+            return "ollama"
+
+        # Gemini can also be inferred from the model string
+        if lowered.startswith("gemini/") or "gemini" in lowered:
             return "gemini"
 
     raise LLMError(

--- a/tests/unit/test_cli_main_additional.py
+++ b/tests/unit/test_cli_main_additional.py
@@ -85,6 +85,30 @@ def test_info_handles_detect_provider_failure(
     assert "Detected provider heuristics: None" in captured.out
 
 
+def test_info_reports_ollama_provider_from_model_env(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(main, "load_config", lambda: {})
+    monkeypatch.setattr(
+        main, "get_env_config", lambda: {"GMUSE_MODEL": "ollama/qwen2.5-coder"}
+    )
+    monkeypatch.setattr(
+        main,
+        "merge_config",
+        lambda **_: {"model": "ollama/qwen2.5-coder"},
+    )
+
+    fake_llm = ModuleType("gmuse.llm")
+    setattr(fake_llm, "detect_provider", lambda: "ollama")
+    monkeypatch.setitem(sys.modules, "gmuse.llm", fake_llm)
+
+    main.info()
+
+    captured = capsys.readouterr()
+    assert "Resolved model: ollama/qwen2.5-coder" in captured.out
+    assert "Detected provider heuristics: ollama" in captured.out
+
+
 @pytest.mark.parametrize(
     ("exc", "exit_code", "expected_hint"),
     [

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -39,6 +39,20 @@ class TestDetectProvider:
         ):
             assert detect_provider() == "gemini"
 
+    def test_detect_ollama_from_model_env(self) -> None:
+        """Detect ollama provider when GMUSE_MODEL indicates an ollama model."""
+        with mock.patch.dict(
+            os.environ, {"GMUSE_MODEL": "ollama/llama3.1"}, clear=True
+        ):
+            assert detect_provider() == "ollama"
+
+    def test_detect_ollama_chat_from_model_env(self) -> None:
+        """Detect ollama provider when GMUSE_MODEL uses the ollama_chat prefix."""
+        with mock.patch.dict(
+            os.environ, {"GMUSE_MODEL": "ollama_chat/llama3.1"}, clear=True
+        ):
+            assert detect_provider() == "ollama"
+
     def test_detect_no_provider_raises_error(self) -> None:
         """Test error when no provider API key is set."""
         with mock.patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## Summary

Add support for treating `GMUSE_MODEL=ollama/...` and `ollama_chat/...` as a configured local provider, and document a recommended local-model workflow for `gmuse`.

## Changes

- detect `ollama` from `GMUSE_MODEL` so local runtimes work without API-key heuristics
- add regression coverage for provider detection and `gmuse info`
- add a new local-model how-to guide and link it from the how-to index and configuration guide

## Validation

- `uv run pytest tests/unit/test_cli_main_additional.py tests/unit/test_llm.py -q`
- `uv run nox -s types`
- `uv run nox -s docs -- -W`
