### PR TITLE
use litellm to detect provider from model name

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -204,7 +204,7 @@
         "filename": "src/gmuse/llm.py",
         "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 129
       }
     ],
     "tests/integration/test_cli.py": [
@@ -240,5 +240,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-23T02:45:18Z"
+  "generated_at": "2026-05-29T02:55:01Z"
 }

--- a/src/gmuse/llm.py
+++ b/src/gmuse/llm.py
@@ -117,18 +117,10 @@ def detect_provider() -> Optional[str]:
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         return "gemini"
 
-    # Check if GMUSE_MODEL explicitly indicates a provider that does not
-    # require an API key (e.g., local runtimes).
+    # Check if GMUSE_MODEL explicitly indicates a provider
     if model := os.getenv("GMUSE_MODEL"):
-        lowered = model.lower()
-
-        # Local runtimes via LiteLLM (no API key required)
-        if lowered.startswith("ollama/") or lowered.startswith("ollama_chat/"):
-            return "ollama"
-
-        # Gemini can also be inferred from the model string
-        if lowered.startswith("gemini/") or "gemini" in lowered:
-            return "gemini"
+        _, provider, _, _ = litellm.get_llm_provider(model)
+        return provider
 
     raise LLMError(
         "No LLM provider API key configured.\n\n"

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -51,7 +51,7 @@ class TestDetectProvider:
         with mock.patch.dict(
             os.environ, {"GMUSE_MODEL": "ollama_chat/llama3.1"}, clear=True
         ):
-            assert detect_provider() == "ollama"
+            assert detect_provider() == "ollama_chat"
 
     def test_detect_no_provider_raises_error(self) -> None:
         """Test error when no provider API key is set."""


### PR DESCRIPTION
Creates a more robust provider dectection than the previous manual checks.