### PR TITLE
Redesign commit UX around generate and commit workflows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read
+`specs/008-commit-ux-redesign/plan.md`
 <!-- SPECKIT END -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-`specs/008-commit-ux-redesign/plan.md`
+the current plan
 <!-- SPECKIT END -->

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/008-commit-ux-redesign"
+}

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,0 @@
-{
-  "feature_directory": "specs/008-commit-ux-redesign"
-}

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -20,6 +20,12 @@ draft and lets you accept, edit, regenerate, or quit before a commit is created.
 - `--model TEXT` / `-m TEXT`: LLM model to use (overrides env/config).
 - `--history-depth INTEGER`: Number of recent commits to use for style context (0–50).
 
+If you prefer editor-first commits, create a shell alias:
+
+```console
+$ alias gmc='gmuse commit --edit'
+```
+
 ## gmuse generate
 
 Generate a commit message from staged changes and write only the message to stdout.

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -1,12 +1,34 @@
 # CLI Reference
 
-## gmuse msg
+## gmuse commit
 
-Generate a commit message from staged changes.
+Generate a commit message from staged changes and use it to create a git commit.
 
 ```console
-$ gmuse msg [OPTIONS]
+$ gmuse commit [OPTIONS]
 ```
+
+By default, `gmuse commit` runs an interactive review flow. It shows the generated
+draft and lets you accept, edit, regenerate, or quit before a commit is created.
+
+### Options
+
+- `--hint TEXT` / `-h TEXT`: Provide a hint to the LLM (e.g., "security fix").
+- `--edit`: Generate a draft, open the editor immediately with that draft prefilled, and commit after the editor exits.
+- `--yes` / `-y`: Generate and commit immediately without prompting. Cannot be combined with `--edit`.
+- `--format TEXT` / `-f TEXT`: Message format: `freeform` (default), `conventional`, or `gitmoji`.
+- `--model TEXT` / `-m TEXT`: LLM model to use (overrides env/config).
+- `--history-depth INTEGER`: Number of recent commits to use for style context (0–50).
+
+## gmuse generate
+
+Generate a commit message from staged changes and write only the message to stdout.
+
+```console
+$ gmuse generate [OPTIONS]
+```
+
+Use this command for scripts, shell integrations, and completion plumbing.
 
 ### Options
 
@@ -14,15 +36,26 @@ $ gmuse msg [OPTIONS]
 - `--format TEXT` / `-f TEXT`: Message format: `freeform` (default), `conventional`, or `gitmoji`.
 - `--model TEXT` / `-m TEXT`: LLM model to use (overrides env/config).
 - `--history-depth INTEGER`: Number of recent commits to use for style context (0–50).
-- `--copy` / `-c`: Copy the generated message to clipboard.
 - `--dry-run`: Print the assembled prompt without calling the LLM provider.
+
+## gmuse msg
+
+Deprecated compatibility alias for `gmuse generate`.
+
+```console
+$ gmuse msg [OPTIONS]
+```
+
+`gmuse msg` emits a deprecation notice on stderr and preserves the stdout-only
+message output contract. Legacy clipboard mode is retired; `gmuse msg --copy`
+fails with migration guidance.
 
 **Note:** Provider selection is auto-detected from configured API keys (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). Empty environment values fall through to the OS keyring, and `gmuse auth` provides the secure setup path for interactive use. See [Configuration Reference](configuration.md#model) for details on provider detection.
 
 ### Dry-run example
 
 ```console
-$ gmuse msg --dry-run
+$ gmuse generate --dry-run
 ```
 
 Output:

--- a/specs/008-commit-ux-redesign/checklists/requirements.md
+++ b/specs/008-commit-ux-redesign/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Breaking CLI UX Redesign for Commit Message Generation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass completed with no unresolved clarification markers.
+- The spec explicitly resolves command migration, completion preservation, and clipboard retirement as behavioral decisions rather than implementation notes.
+

--- a/specs/008-commit-ux-redesign/checklists/requirements.md
+++ b/specs/008-commit-ux-redesign/checklists/requirements.md
@@ -33,4 +33,3 @@
 
 - Validation pass completed with no unresolved clarification markers.
 - The spec explicitly resolves command migration, completion preservation, and clipboard retirement as behavioral decisions rather than implementation notes.
-

--- a/specs/008-commit-ux-redesign/contracts/cli-commands.md
+++ b/specs/008-commit-ux-redesign/contracts/cli-commands.md
@@ -1,0 +1,226 @@
+# CLI Contract: commit / generate / msg
+
+**Feature**: 008-commit-ux-redesign
+**Date**: 2026-06-06
+
+## Top-level help contract
+
+`gmuse --help` must present `commit` as the primary workflow and `generate` as the raw primitive.
+
+```text
+Usage: gmuse [OPTIONS] COMMAND [ARGS]...
+
+  gmuse: AI generated commit messages.
+
+  Primary workflow:
+    gmuse commit      Generate a draft and create a git commit
+
+  Raw generation:
+    gmuse generate    Print a generated commit message to stdout
+
+  Compatibility:
+    gmuse msg         Deprecated alias for 'gmuse generate'
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+```
+
+`git-completions`, `git-completions-run`, `config`, `auth`, and `info` remain available.
+
+---
+
+## Command: `gmuse commit`
+
+### Signature
+
+```text
+gmuse commit [OPTIONS]
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--hint` | str | `None` | Additional generation guidance |
+| `--model`, `-m` | str | `None` | LLM model override |
+| `--format`, `-f` | str | resolved config | Commit message format |
+| `--history-depth` | int | resolved config | Number of recent commits for style context |
+| `--temperature` | float | resolved config | Sampling override |
+| `--max-tokens` | int | resolved config | Response token cap |
+| `--max-diff-bytes` | int | resolved config | Diff truncation threshold |
+| `--include-branch` | bool | false | Include sanitized branch context |
+| `--yes`, `-y` | bool | false | Skip review and commit the first generated draft immediately |
+| `--help` | bool | false | Show help and exit |
+
+### Behavior contract
+
+1. Reuse the same raw generation inputs and validation rules as `gmuse generate`.
+2. If `--yes` is set:
+   - generate one draft;
+   - run a direct `git commit`;
+   - do not prompt or launch an editor.
+3. If `--yes` is not set and stdin/stdout are interactive:
+   - generate one draft;
+   - display the draft for review;
+   - present `accept`, `edit`, `regenerate`, and `abort` actions.
+4. `accept` creates a commit from the current draft without another LLM call.
+5. `edit` launches the user's normal git editor flow with the draft prefilled.
+6. `regenerate` requests a fresh draft and returns to the same review step.
+7. `abort` exits without creating a commit.
+8. If stdin/stdout are not interactive and `--yes` is not set, fail fast with actionable guidance.
+9. `gmuse commit` must not expose `--copy`.
+10. Legacy clipboard config/env inputs must not cause commit-time copy side effects.
+
+### Success output
+
+**Interactive accept**:
+
+```text
+Draft commit message:
+
+feat: add branch-aware commit flow
+
+Choose an action: [a]ccept, [e]dit, [r]egenerate, [x]abort
+```
+
+On commit success, the command may print a concise success confirmation or stream git's normal success output, but it must not claim success before git returns exit code `0`.
+
+### Non-interactive guard
+
+**Error (exit code 1)**:
+
+```text
+Error: gmuse commit requires an interactive terminal unless --yes is provided.
+
+Use 'gmuse commit --yes' to commit immediately, or 'gmuse generate' for stdout-only output.
+```
+
+### Git/editor failure shape
+
+**Error (exit code 1)**:
+
+```text
+Error: Git could not create the commit.
+
+<git stderr or actionable summary>
+```
+
+If the editor path exits without creating a commit, the command must report that no commit was created and must not print a success-shaped message.
+
+---
+
+## Command: `gmuse generate`
+
+### Signature
+
+```text
+gmuse generate [OPTIONS]
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--hint` | str | `None` | Additional generation guidance |
+| `--model`, `-m` | str | `None` | LLM model override |
+| `--format`, `-f` | str | resolved config | Commit message format |
+| `--history-depth` | int | resolved config | Number of recent commits for style context |
+| `--temperature` | float | resolved config | Sampling override |
+| `--max-tokens` | int | resolved config | Response token cap |
+| `--max-diff-bytes` | int | resolved config | Diff truncation threshold |
+| `--include-branch` | bool | false | Include sanitized branch context |
+| `--dry-run` | bool | false | Print the assembled prompt instead of calling the provider |
+| `--help` | bool | false | Show help and exit |
+
+### Behavior contract
+
+1. Gather context through the existing shared generation path.
+2. On success, print only the generated message to stdout.
+3. Preserve truncation warnings on stderr when diff context is reduced.
+4. Preserve existing prerequisite failures for not-a-repo, no staged changes, missing credentials, and invalid generated output.
+5. Never prompt, open an editor, create a git commit, or perform clipboard actions.
+6. Do not expose `--copy`.
+7. Ignore passive legacy clipboard config/env inputs so raw success stays stdout-only.
+
+### Success output
+
+```text
+feat: add branch-aware commit flow
+```
+
+### Dry-run output
+
+`--dry-run` continues to print prompt-inspection output instead of a generated message and does not call the LLM provider.
+
+---
+
+## Command: `gmuse msg`
+
+### Signature
+
+```text
+gmuse msg [OPTIONS]
+```
+
+### Compatibility policy
+
+- `gmuse msg` is a temporary deprecated alias for `gmuse generate`.
+- During the transition line it must preserve raw stdout compatibility for existing scripts.
+- Deprecation guidance must be written to stderr, not stdout.
+
+### Behavior contract
+
+1. Accept the same raw-generation options as `gmuse generate`, except for retired clipboard behavior.
+2. Emit a deprecation notice naming:
+   - `gmuse generate` for raw-output workflows
+   - `gmuse commit` for direct commit workflows
+3. Delegate to the same shared raw-generation helper as `gmuse generate`.
+4. Keep stdout identical to `gmuse generate` on success.
+
+### Deprecation notice
+
+```text
+Warning: 'gmuse msg' is deprecated and will be removed after the transition period.
+
+Use 'gmuse generate' for stdout-only commit message generation.
+Use 'gmuse commit' to generate a draft and create the git commit directly.
+```
+
+### Legacy clipboard failure
+
+If a user runs `gmuse msg --copy`, the command must fail and must not generate a commit message.
+
+**Error (exit code 1)**:
+
+```text
+Error: Clipboard-first behavior has been retired.
+
+Use 'gmuse commit' to create the commit directly, or pipe 'gmuse generate' into your own clipboard tool.
+```
+
+---
+
+## Legacy clipboard inputs
+
+### Removed CLI flag
+
+- `--copy` must not appear in `gmuse commit --help` or `gmuse generate --help`.
+- `gmuse msg --copy` is retained only as a migration error trigger.
+
+### Legacy environment/config compatibility
+
+| Legacy input | New contract |
+|--------------|--------------|
+| `GMUSE_COPY` | Deprecated; parsed only for compatibility, but must not trigger copy behavior on `generate`, `commit`, or completion runtime |
+| `copy_to_clipboard` | Deprecated; same compatibility rule as `GMUSE_COPY` |
+
+These inputs may produce migration warnings in user-facing command paths, but they must never contaminate `gmuse generate` stdout.
+
+## Exit codes
+
+| Exit Code | Meaning |
+|-----------|---------|
+| `0` | Success |
+| `1` | User-facing CLI/git/migration/prerequisite error |
+| `2` | Provider or generated-message validation failure on raw generation paths |

--- a/specs/008-commit-ux-redesign/contracts/completion-runtime.md
+++ b/specs/008-commit-ux-redesign/contracts/completion-runtime.md
@@ -1,0 +1,98 @@
+# Runtime Contract: completion and raw generation
+
+**Feature**: 008-commit-ux-redesign
+**Date**: 2026-06-06
+
+## Overview
+
+This contract preserves `gmuse git-completions-run` as a dedicated runtime helper for shell completion while the main CLI shifts to `gmuse commit` and `gmuse generate`.
+
+The key invariant is unchanged:
+
+- shell completion uses a raw-generation path;
+- shell completion never enters the interactive commit-session flow.
+
+## Shared generation boundary
+
+Completion-time suggestion generation must continue to reuse the same underlying raw generation primitive as `gmuse generate`.
+
+That primitive must:
+
+1. gather staged diff and other generation context;
+2. call `gmuse.commit.generate_message()` or an extracted equivalent helper;
+3. return a generated message without commit/editor/clipboard side effects.
+
+`gmuse commit` orchestration must live above this boundary and must not be imported into completion-time control flow.
+
+## Command contract: `gmuse git-completions-run`
+
+### Signature
+
+```text
+gmuse git-completions-run --shell zsh --for "git commit -m" [--timeout FLOAT]
+```
+
+### Input validation
+
+1. `--shell` currently accepts only `zsh`.
+2. `--for` must describe a `git commit` command.
+3. Invalid inputs return structured JSON with `status = "error"`.
+
+### Success contract
+
+On success, stdout must contain JSON only:
+
+```json
+{"suggestion":"feat: add branch-aware commit flow","status":"ok","metadata":{"elapsed_ms":420,"truncated":false}}
+```
+
+The helper must never print prompts, menus, editor notices, clipboard notices, or plain-text migration warnings to stdout.
+
+## Status mapping
+
+| Condition | `status` | `suggestion` | Notes |
+|-----------|----------|--------------|-------|
+| Suggestion generated successfully | `ok` | generated message | Includes `elapsed_ms`; may include `truncated` |
+| Credential lookup timeout / provider timeout | `timeout` | empty | Preserve existing timeout semantics |
+| Missing auth or offline-safe credential failure | `offline` | empty | No shell-visible prompt |
+| No staged changes | `no_staged_changes` | empty | Structured JSON only |
+| Invalid shell / invalid `--for` / unexpected runtime error | `error` | empty | Structured JSON only |
+
+## Non-interactive safety contract
+
+Completion runtime must never:
+
+- invoke `gmuse commit`;
+- enter the review loop;
+- prompt for accept/edit/regenerate/abort;
+- launch `git commit`;
+- launch an editor;
+- read from stdin interactively;
+- perform clipboard work.
+
+This remains true even if:
+
+- `GMUSE_COPY` is set;
+- `copy_to_clipboard = true` exists in config;
+- the main CLI defaults to `gmuse commit`.
+
+## Logging and output isolation
+
+- JSON output must remain machine-parseable.
+- Existing debug-log suppression for completion invocations must remain in place unless logging is redirected to a file.
+- User-facing migration warnings for deprecated clipboard inputs must not be emitted on the completion path.
+
+## Timeout and performance contract
+
+- Completion must continue honoring `--timeout` and `GMUSE_COMPLETIONS_TIMEOUT`.
+- Completion-specific timeout handling stays local to `src/gmuse/cli/completions.py`.
+- Refactors for the new `generate` command must not add extra LLM calls or commit-session overhead to completion requests.
+
+## Regression requirements
+
+Phase 2 implementation must preserve these observable properties:
+
+1. `gmuse git-completions-run` still returns JSON only.
+2. Completion requests still use raw generation rather than interactive commit logic.
+3. Clipboard retirement does not change completion output shape.
+4. Existing timeout/offline/no-staged-changes status behavior remains intact.

--- a/specs/008-commit-ux-redesign/data-model.md
+++ b/specs/008-commit-ux-redesign/data-model.md
@@ -1,0 +1,171 @@
+# Data Model: commit UX redesign
+
+## Entity: `GenerationRequest`
+
+Represents the shared non-interactive inputs used by `gmuse generate`, deprecated `gmuse msg`, `gmuse commit`, and `gmuse git-completions-run`.
+
+**Fields**:
+
+- `hint: str | None`
+  - Optional user guidance to bias generation.
+- `model: str | None`
+  - Optional explicit model override.
+- `format: Literal["freeform", "conventional", "gitmoji"]`
+  - Message-shaping format.
+- `history_depth: int`
+  - Recent commit count used for style context.
+- `temperature: float | None`
+  - Optional model sampling override.
+- `max_tokens: int | None`
+  - Optional model response cap.
+- `max_diff_bytes: int | None`
+  - Diff truncation threshold.
+- `include_branch: bool`
+  - Whether sanitized branch context is included.
+- `dry_run: bool`
+  - Prompt-inspection mode for the raw path only.
+
+**Rules**:
+
+- This entity reuses the existing config-resolution and `gmuse.commit` generation path.
+- `dry_run = true` is valid for the raw generation path and invalid for `gmuse commit`.
+- Clipboard-oriented inputs are not part of this entity after the redesign.
+
+## Entity: `GeneratedDraft`
+
+Represents one AI-produced commit message draft.
+
+**Fields**:
+
+- `message: str`
+  - Full generated commit message, including optional body.
+- `generation_index: int`
+  - Monotonic counter within one commit session, starting at `1`.
+- `context_truncated: bool`
+  - Whether the staged diff was truncated before generation.
+- `source_command: Literal["generate", "msg", "commit", "git-completions-run"]`
+  - Which command surface requested the draft.
+
+**Validation Rules**:
+
+- `message` must already satisfy existing `validate_message()` rules.
+- Multi-line messages must preserve subject/body structure end-to-end.
+- A later regenerated draft replaces the current draft for commit purposes but does not mutate prior session history.
+
+## Entity: `ReviewAction`
+
+Represents a user decision in the interactive `gmuse commit` review loop.
+
+**Allowed values**:
+
+- `accept`
+- `edit`
+- `regenerate`
+- `abort`
+
+**Rules**:
+
+- Only available when stdin and stdout are interactive and `--yes` is not set.
+- `regenerate` is the only action that requests another LLM call.
+- `abort` never creates a git commit.
+
+## Entity: `CommitSession`
+
+Represents one invocation of `gmuse commit`.
+
+**Fields**:
+
+- `request: GenerationRequest`
+  - Shared generation inputs for the session.
+- `drafts: list[GeneratedDraft]`
+  - Ordered draft history for the current session.
+- `current_draft_index: int`
+  - Index of the active draft in `drafts`.
+- `interactive: bool`
+  - `True` when both stdin and stdout are TTYs and `--yes` is not set.
+- `fast_path: bool`
+  - `True` when `--yes` bypasses the review loop.
+- `selected_action: ReviewAction | None`
+  - Most recent interactive action.
+- `outcome: CommitOutcome | None`
+  - Final session result once execution ends.
+
+**State Transitions**:
+
+1. Session starts with one generated draft.
+2. If `fast_path = true`, the session attempts direct commit immediately.
+3. If `interactive = true`, the session enters review:
+   - `accept` -> direct commit attempt
+   - `edit` -> editor handoff commit attempt
+   - `regenerate` -> append new draft and return to review
+   - `abort` -> terminal non-commit outcome
+4. Any git/editor failure ends the session with a failed outcome and no false-success message.
+
+## Entity: `CommitOutcome`
+
+Represents the terminal result of a commit session.
+
+**Fields**:
+
+- `status: Literal["committed", "aborted", "failed"]`
+- `method: Literal["accept", "edit", "yes", "none"]`
+  - `none` is used for aborts and preflight failures before a commit attempt.
+- `commit_created: bool`
+- `head_changed: bool`
+  - Whether `HEAD` advanced during the command.
+- `message_used: str | None`
+  - Final committed message when a commit succeeds.
+- `error_kind: Literal["non_interactive", "git_rejected", "editor_failed", "validation", "prerequisite", "none"]`
+- `error_message: str | None`
+
+**Rules**:
+
+- `status = "committed"` requires `commit_created = true`, `head_changed = true`, and a non-empty `message_used`.
+- `status = "aborted"` requires `commit_created = false`.
+- `status = "failed"` requires a non-`none` `error_kind`.
+- Editor exits that do not create a commit are modeled as `aborted` or `failed` based on the observed git result, not guessed from prompt text alone.
+
+## Entity: `RawGenerationOutput`
+
+Represents the success contract for `gmuse generate`, deprecated `gmuse msg`, and completion-time raw generation.
+
+**Fields**:
+
+- `message: str`
+  - Exact generated commit message content.
+- `stdout_only: bool`
+  - Indicates that success output is limited to the message payload for CLI raw generation.
+- `side_effects: Literal["none"]`
+
+**Rules**:
+
+- On successful `gmuse generate`, stdout contains only `message`.
+- No clipboard, editor, prompt, or `git commit` side effect is allowed on this path.
+- Completion runtime wraps the message in JSON but still relies on the same raw-generation primitive.
+
+## Entity: `MigrationNotice`
+
+Represents user-facing guidance for renamed or removed CLI surfaces.
+
+**Fields**:
+
+- `trigger: Literal["msg_alias", "msg_copy", "gmuse_copy_env", "copy_to_clipboard_config"]`
+- `severity: Literal["deprecation", "error"]`
+- `replacement_raw_command: str`
+  - Always `gmuse generate`.
+- `replacement_commit_command: str`
+  - Always `gmuse commit`.
+- `details: str`
+
+**Rules**:
+
+- `msg_alias` emits a deprecation notice to stderr while preserving stdout compatibility.
+- `msg_copy` is a hard error with explicit migration guidance.
+- Passive legacy clipboard config/env inputs may trigger warnings or deprecation tracking, but must not violate the stdout-only success contract of `gmuse generate`.
+
+## Relationships
+
+- A `CommitSession` owns one or more `GeneratedDraft` records.
+- A `CommitSession` ends in exactly one `CommitOutcome`.
+- A `MigrationNotice` may be emitted by `gmuse msg`, `gmuse commit`, or `gmuse generate`, but does not alter raw generation semantics on success.
+- `RawGenerationOutput.message` should equal the active `GeneratedDraft.message` when both arise from the same shared generation helper.

--- a/specs/008-commit-ux-redesign/plan.md
+++ b/specs/008-commit-ux-redesign/plan.md
@@ -1,0 +1,277 @@
+# Implementation Plan: Breaking CLI UX Redesign for Commit Message Generation
+
+**Branch**: `008-commit-ux-redesign` | **Date**: 2026-06-06 | **Spec**: ../008-commit-ux-redesign/spec.md
+**Input**: Feature specification from `specs/008-commit-ux-redesign/spec.md`
+
+
+## Summary
+
+Promote `gmuse commit` to the primary user workflow by splitting today's `gmuse msg`
+behavior into two explicit layers:
+
+1. a raw stdout-only generation primitive exposed as `gmuse generate` (with
+   `gmuse msg` kept temporarily as a deprecated alias), and
+2. a new commit-session workflow exposed as `gmuse commit` that generates a draft,
+   lets the user accept/edit/regenerate/abort, and then executes `git commit`
+   directly.
+
+The implementation should keep `gmuse.commit.generate_message` and the existing
+completion runtime helper as the shared non-interactive generation path, while
+moving commit orchestration, editor handoff, non-interactive guards, and migration
+messaging into focused CLI helpers. Clipboard-first behavior becomes a migration
+case rather than a supported workflow.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+
+
+**Primary Dependencies**: Typer CLI, existing gmuse prompt/generation stack
+(`gmuse.commit`, LiteLLM-backed `gmuse.llm`), standard library (`subprocess`,
+`os`, `sys`), pytest, Ruff, pyrefly
+
+**Storage**: Existing filesystem/git repository state plus current env/config
+inputs; no new persistent storage
+
+**Testing**: pytest unit + integration tests, with mocked LLM/generic git command
+execution for CLI review flows and real temporary git repositories for end-to-end
+behavior
+
+**Target Platform**: Local Python CLI on Linux, macOS, and Windows in both
+interactive terminals and non-interactive/scripted environments
+
+**Project Type**: Single Python package (`src/gmuse`) with a Typer-based CLI
+entrypoint
+
+**Performance Goals**: Preserve current single-generation latency for
+`gmuse generate` and `gmuse commit --yes`; keep default interactive review to one
+generation per draft unless the user explicitly regenerates; preserve completion
+runtime behavior through the existing raw generation/helper path
+
+**Constraints**: `gmuse generate` stdout must remain message-only on success;
+`gmuse commit` must never hang in non-interactive environments without `--yes`;
+completion support must continue through `gmuse git-completions-run` rather than
+the interactive command; existing message-shaping options must remain available;
+breaking rename/removal behavior must ship with explicit migration guidance
+
+**Scale/Scope**: Cross-cutting CLI redesign touching command registration, git
+execution, deprecated clipboard/config handling, completion/runtime contracts,
+documentation, and acceptance/integration coverage
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution gates for this feature:
+
+- **Code Quality Gate**: Pass. The redesign can stay modular by keeping raw
+  generation in existing service code and introducing a small commit-session
+  helper/module rather than embedding review-loop and git-commit subprocess logic
+  directly into `src/gmuse/cli/main.py`.
+- **Testing Gate**: Pass. The plan includes unit coverage for command wiring,
+  migration errors, and review-loop branching plus integration coverage for
+  interactive/non-interactive commit flows, deprecated aliases, and completion
+  behavior.
+- **UX Gate**: Pass. This is a breaking CLI change, so help text, errors,
+  deprecation notices, quickstart material, and configuration docs are all part of
+  the implementation scope.
+- **Performance Gate**: Pass. The shared raw generation path is retained, no extra
+  provider calls are added on accept/abort flows, and completion plumbing remains
+  decoupled from interactive prompts and editor launch behavior.
+- **Security/Privacy Gate**: Pass. The redesign does not add new secret storage;
+  it preserves existing credential resolution, keeps completion output structured,
+  and avoids leaking generated drafts or credential state through unexpected prompt
+  flows.
+- **Release Discipline Gate**: Pass. The plan explicitly includes a transitional
+  `gmuse msg` alias, migration messaging for retired clipboard behavior, and docs
+  updates appropriate for a pre-1.0 breaking change.
+
+Checklist:
+
+- Code Quality Gate: Yes — add a focused commit-session orchestration layer and
+  keep `main.py` thin.
+- Testing Gate: Yes — cover raw generation, review actions, git failures,
+  deprecation messages, and completion invariants.
+- UX Gate: Yes — update help, docs, migration guidance, and command descriptions.
+- Performance Gate: Yes — keep completion/runtime generation on the raw helper
+  path and avoid extra LLM calls unless the user asks to regenerate.
+- Security/Privacy Gate: Yes — no new persistence or secret exposure paths.
+- Release Discipline Gate: Yes — breaking rename/removal ships with transitional
+  aliasing and documented migration.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-commit-ux-redesign/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── cli-commands.md
+│   └── completion-runtime.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/gmuse/
+├── cli/
+│   ├── main.py                # command registration, renamed surfaces, help text
+│   ├── completions.py         # preserve raw completion/runtime-helper contract
+│   ├── config_resolution.py   # shared option/config resolution if command plumbing changes
+│   └── commit_session.py      # new interactive review + direct commit orchestration
+├── commit.py                  # shared raw draft generation service remains the primitive
+├── config.py                  # retire/deprecate clipboard-centric config/env handling
+├── exceptions.py              # non-interactive/migration/git-commit UX errors as needed
+└── git.py                     # add commit execution/editor handoff helpers around git
+
+tests/
+├── integration/
+│   ├── test_cli.py
+│   ├── test_cli_generate_commit.py
+│   └── test_completions_run.py
+└── unit/
+    ├── test_cli_main.py
+    ├── test_cli_completions.py
+    ├── test_cli_commit_session.py
+    ├── test_commit.py
+    └── test_config.py
+
+docs/source/
+├── reference/
+│   ├── cli.md
+│   └── configuration.md
+├── tutorials/
+│   └── quickstart.md
+├── how_to/
+│   ├── completions.md
+│   ├── configuration.md
+│   └── troubleshooting.md
+├── explanation/
+│   └── how_it_works.md
+└── development/
+    └── shell-completions.md
+
+README.md
+```
+
+**Structure Decision**: Keep the existing single-package CLI structure. Introduce
+one small orchestration module for the interactive commit session and extend the
+existing git/config/CLI modules around it, while preserving `gmuse.commit` and
+`gmuse.cli.completions` as the shared raw generation path used by scripts and
+completion helpers.
+
+## Complexity Tracking
+
+No constitution violations are expected for this feature.
+
+## Phase 0 — Outline & Research (Output: `research.md`)
+
+Research focus areas:
+
+- Determine the safest cross-platform git invocation for:
+  - accepting a reviewed draft immediately,
+  - opening the user's normal git editor flow with a generated draft prefilled, and
+  - surfacing hook/editor failures without creating false-success UX.
+- Define the compatibility policy for legacy clipboard inputs (`--copy`,
+  `GMUSE_COPY`, and `copy_to_clipboard`) so the new raw command remains
+  stdout-only while users still get actionable migration guidance.
+- Confirm the Typer command/alias strategy for making `gmuse commit` primary,
+  introducing `gmuse generate`, and keeping `gmuse msg` as a temporary deprecated
+  alias without disturbing `python -m gmuse` entrypoint behavior.
+- Confirm test techniques for the interactive review loop, especially regenerate
+  cycles and editor/abort outcomes in automated tests.
+- Re-verify the completion contract so `gmuse git-completions-run` continues to
+  call the shared raw generation path and never enters interactive commit logic.
+
+Output artifact:
+
+- `specs/008-commit-ux-redesign/research.md`
+
+## Phase 1 — Design & Contracts (Outputs: `data-model.md`, `contracts/`, `quickstart.md`)
+
+Design artifacts:
+
+- Session/data model for drafts, review actions, commit outcomes, and migration
+  notices: `specs/008-commit-ux-redesign/data-model.md`
+- CLI surface contract covering `commit`, `generate`, deprecated `msg`, and
+  retired clipboard inputs: `specs/008-commit-ux-redesign/contracts/cli-commands.md`
+- Completion/runtime contract documenting the preserved raw helper path:
+  `specs/008-commit-ux-redesign/contracts/completion-runtime.md`
+- User migration walkthrough and examples:
+  `specs/008-commit-ux-redesign/quickstart.md`
+
+Phase 1 agent context update:
+
+- Update `.github/copilot-instructions.md` so the Speckit plan reference points to
+  `specs/008-commit-ux-redesign/plan.md`.
+
+Post-design constitution re-check:
+
+- Code Quality: keep raw generation and commit-session orchestration separate.
+- Testing: verify both review-loop branches and raw generation/alias behavior.
+- UX: confirm help output, migration text, and docs all present `commit` as the
+  main workflow.
+- Performance: completion/runtime helper still bypasses interactive logic.
+- Security/Privacy: no new credential or draft leakage through prompts/logging.
+- Release Discipline: transitional alias and retired clipboard guidance are fully
+  documented before implementation starts.
+
+## Phase 2 — Implementation Planning (Tasks breakdown; `tasks.md` created by `/speckit.tasks`)
+
+Planned implementation steps:
+
+1. Extract the current `gmuse msg` generation flow in `src/gmuse/cli/main.py`
+   into a shared raw-generation command helper that gathers context, preserves the
+   current message-shaping flags, warns on truncation, and prints only the
+   generated message to stdout on success.
+2. Add a new top-level `gmuse generate` command that uses that helper as the
+   supported scripting/completion primitive and carries forward existing generation
+   options such as `--hint`, `--format`, `--model`, `--history-depth`,
+   `--temperature`, `--max-tokens`, `--max-diff-bytes`, `--include-branch`, and
+   prompt-inspection/debug options that still belong on the raw path.
+3. Convert `gmuse msg` into a temporary deprecated alias for `gmuse generate`,
+   emitting deprecation guidance on stderr while preserving stdout compatibility
+   for scripts that still consume the generated message.
+4. Add a new `gmuse commit` command that reuses the shared generation inputs,
+   defaults to an interactive review flow when stdin/stdout are TTYs, and supports
+   `--yes` as the explicit non-interactive fast path.
+5. Implement a dedicated commit-session helper (`src/gmuse/cli/commit_session.py`)
+   that manages review state and actions:
+   - accept → create the git commit from the current draft,
+   - edit → hand off to the user's normal git authoring/editor flow with the draft
+     prefilled,
+   - regenerate → request a fresh draft through the shared raw generation service,
+   - abort → exit without creating a commit.
+6. Extend `src/gmuse/git.py` (or the new session helper) with thin wrappers for
+   direct commit execution and editor handoff so git hook failures, editor launch
+   failures, and empty-message exits are surfaced consistently and testably.
+7. Add an explicit non-interactive guard so `gmuse commit` without `--yes` fails
+   fast outside an interactive terminal with guidance to use `gmuse commit --yes`
+   or `gmuse generate`.
+8. Retire clipboard-first behavior from the primary CLI surface:
+   - remove `--copy` from `commit`/`generate` help,
+   - stop honoring clipboard behavior on the new primary/raw commands,
+   - make legacy clipboard usage through `gmuse msg --copy` fail with migration
+     guidance,
+   - deprecate or reject `GMUSE_COPY` / `copy_to_clipboard` in a way that does not
+     violate the raw stdout-only contract.
+9. Keep `src/gmuse/cli/completions.py` on the raw generation/runtime-helper path,
+   reusing shared generation helpers where helpful, while explicitly avoiding any
+   dependency on the interactive commit session.
+10. Update command descriptions, top-level help text, README, CLI reference,
+    quickstart, configuration docs, troubleshooting guides, and completion docs so
+    `gmuse commit` is clearly primary, `gmuse generate` is clearly the primitive,
+    and the `gmuse msg`/clipboard migration story is easy to follow.
+11. Add unit tests for command registration/help ordering, deprecated alias
+    messaging, non-interactive guard behavior, commit-session branching,
+    clipboard-migration failures, and unchanged raw generation option plumbing.
+12. Add integration tests covering:
+    - `gmuse commit` accept, edit, regenerate, abort, and `--yes`,
+    - failure paths for no staged changes, git commit rejection, and editor issues,
+    - `gmuse generate` stdout-only behavior,
+    - `gmuse msg` deprecation behavior and `msg --copy` migration errors,
+    - unchanged JSON-based completion behavior via `gmuse git-completions-run`.

--- a/specs/008-commit-ux-redesign/quickstart.md
+++ b/specs/008-commit-ux-redesign/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart: commit UX redesign
+
+This redesign makes `gmuse commit` the main workflow, keeps `gmuse generate` as the scripting primitive, and turns `gmuse msg` into a temporary deprecated alias.
+
+## 1. Review and commit interactively
+
+```bash
+gmuse commit
+```
+
+Expected behavior:
+
+- `gmuse` generates a draft from staged changes.
+- The draft is shown before any commit is created.
+- You can accept, edit, regenerate, or abort.
+
+Use this when you want `gmuse` to replace the old “generate, copy, then run `git commit`” workflow.
+
+## 2. Commit immediately when you trust the first draft
+
+```bash
+gmuse commit --yes
+```
+
+Expected behavior:
+
+- `gmuse` generates one draft.
+- It immediately runs `git commit` with that message.
+- No review prompt or editor is opened.
+
+Use this for the fastest explicit one-command path.
+
+## 3. Generate a raw message for scripts or pipes
+
+```bash
+gmuse generate
+```
+
+Expected behavior:
+
+- stdout contains only the generated commit message.
+- No commit is created.
+- No editor or review UI appears.
+
+That makes `gmuse generate` the supported replacement for scripts that previously consumed `gmuse msg`.
+
+## 4. Keep using the old command during the transition
+
+```bash
+gmuse msg
+```
+
+Expected behavior:
+
+- stdout behaves like `gmuse generate`.
+- stderr shows a deprecation notice telling you to migrate.
+
+Use this only as a short-term compatibility path while updating habits and scripts.
+
+## 5. Migrate old clipboard workflows
+
+Old workflow:
+
+```bash
+gmuse msg --copy
+```
+
+New supported options:
+
+```bash
+gmuse commit
+```
+
+or, if you still want a shell clipboard pipeline:
+
+```bash
+gmuse generate | pbcopy
+```
+
+Expected behavior:
+
+- `gmuse msg --copy` now fails with migration guidance.
+- `gmuse commit` is the direct replacement for “generate then commit”.
+- `gmuse generate | <clipboard-tool>` is the replacement for personal copy-based shell workflows.
+
+## 6. Non-interactive environments must choose explicitly
+
+If you are in a non-interactive environment:
+
+```bash
+gmuse commit
+```
+
+must fail fast with guidance to use:
+
+```bash
+gmuse commit --yes
+```
+
+or:
+
+```bash
+gmuse generate
+```
+
+This prevents hidden hangs waiting for prompt input.
+
+## 7. Shell completions stay on the raw path
+
+```bash
+gmuse git-completions-run --shell zsh --for "git commit -m"
+```
+
+Expected behavior:
+
+- completion still returns JSON only;
+- completion still uses raw generation;
+- completion never opens the interactive commit flow.

--- a/specs/008-commit-ux-redesign/research.md
+++ b/specs/008-commit-ux-redesign/research.md
@@ -1,0 +1,184 @@
+# Phase 0 Research: commit UX redesign
+
+## Current implementation baseline
+
+- `gmuse` currently exposes `msg`, `info`, `auth`, `config`, `git-completions`, and `git-completions-run` from `src/gmuse/cli/main.py`.
+- Raw generation already has a reusable service boundary in `gmuse.commit.gather_context()` and `gmuse.commit.generate_message()`.
+- Clipboard behavior is currently mixed into the `msg` command via `--copy`, `GMUSE_COPY`, and `copy_to_clipboard`.
+- Shell completion already bypasses `msg` and calls `gmuse.cli.completions.completions_run_command()` directly, which emits JSON and calls `generate_message()` without invoking CLI prompts.
+- `python -m gmuse` is a thin wrapper around the same Typer app in `src/gmuse/__main__.py`, so command registration changes in `main.py` automatically apply to both entrypoints.
+- The existing test suite already uses the two patterns this feature needs:
+  1. unit tests with monkeypatch/mocks around CLI helpers, and
+  2. integration tests with `CliRunner` plus real temporary git repositories.
+
+## Research decisions
+
+### 1. Git invocation strategy
+
+#### Accept / `--yes`
+
+Use:
+
+```text
+git commit --cleanup=verbatim --file -
+```
+
+and pass the generated draft through `subprocess.run(..., input=message, text=True)`.
+
+Why this is the safest fit:
+
+- avoids shell quoting problems entirely;
+- preserves multiline messages without splitting subject/body across repeated `-m` flags;
+- works cross-platform with normal `subprocess` argument lists;
+- keeps the commit message off the process list;
+- lets git still run normal hooks and validation.
+
+#### Edit
+
+Use:
+
+```text
+git commit --cleanup=verbatim --edit --file <tempfile>
+```
+
+where `<tempfile>` contains the generated draft and is created with standard-library temp-file APIs.
+
+Why this is the best handoff:
+
+- `--edit` preserves the normal git editor flow instead of inventing a custom editor UX;
+- `--file` pre-fills the draft exactly once, which matches the requirement better than `--template`;
+- a temp file is simpler and more portable than trying to synthesize editor state through environment tricks;
+- the generated draft remains the initial message even if the user has a personal `commit.template`.
+
+`--template` is not the preferred mechanism here because git aborts when the template is left unedited, which makes “open the editor and keep the draft mostly as-is” unnecessarily fragile.
+
+#### Failure handling
+
+Add thin wrappers in `src/gmuse/git.py` (or a small helper module beside it) that:
+
+- call `subprocess.run(..., check=False, capture_output=True, text=True)`;
+- treat exit code `0` as the only success path;
+- surface stderr/stdout details on failure without printing a success-shaped message first;
+- map failures into three user-facing buckets:
+  1. **commit rejected**: hook failure, validation failure, or other git refusal;
+  2. **editor launch/edit failure**: editor exits non-zero or git reports it could not launch the editor;
+  3. **user-aborted/no commit created**: editor path exits without creating a commit.
+
+For the editor path, the wrapper should compare `HEAD` before and after the command when possible. That makes “non-zero but no commit created” explicit and avoids guessing solely from stderr text.
+
+### 2. Clipboard compatibility policy
+
+The new command split should treat clipboard support as retired behavior, not as a first-class feature to preserve.
+
+Recommended policy:
+
+- `gmuse generate` stays strictly raw-output oriented and never performs clipboard work.
+- `gmuse commit` also ignores clipboard settings; its job is to commit, not copy.
+- `gmuse msg` remains temporarily available as a deprecated alias for raw generation.
+- `gmuse msg --copy` becomes a hard migration error with clear guidance:
+  - use `gmuse commit` for direct commits;
+  - use `gmuse generate | <clipboard-tool>` if the user still wants a copy-based shell workflow.
+
+For legacy config/env inputs:
+
+- continue parsing `GMUSE_COPY` and `copy_to_clipboard` for one transition line so old config files do not crash command startup;
+- treat them as inert no-ops on `generate`, `commit`, and `git-completions-run`;
+- document them as deprecated and remove them from help/examples;
+- reject new writes to that setting in config-management UX if the config command is updated as part of the redesign.
+
+This balances migration guidance against the raw-command contract:
+
+- success on `gmuse generate` still writes only the message to stdout;
+- completion behavior is not destabilized by stale clipboard env/config;
+- explicit clipboard requests fail loudly, but passive old settings do not silently alter the new command behavior.
+
+### 3. Typer command and alias strategy
+
+The cleanest Typer shape is:
+
+- keep one undecorated helper for shared raw-generation option parsing/execution;
+- expose that helper through a real `generate` command;
+- expose a separate `msg` command wrapper that emits a deprecation notice to stderr, then delegates to the same helper;
+- add a separate `commit` command that reuses the same generation inputs but routes into the new commit-session orchestration.
+
+Implementation notes:
+
+- register `commit` before `generate`/`msg` so help output presents the new primary workflow first;
+- keep `git-completions-run` as its own top-level command;
+- do not implement `generate` by shelling out to `msg`, or `msg` by shelling out to `generate`; both should call shared Python helpers directly;
+- keep `src/gmuse/__main__.py` unchanged so `python -m gmuse` continues to invoke the same app object.
+
+Typer does not need a special alias mechanism here. A small deprecated wrapper is clearer than trying to force one command object to carry multiple behavioral modes.
+
+### 4. Interactive review-loop test strategy
+
+The feature is testable with the repo’s existing pytest patterns.
+
+#### Unit tests
+
+Prefer a small orchestration layer in `src/gmuse/cli/commit_session.py` that depends on injectable helpers for:
+
+- draft generation;
+- prompting for the next review action;
+- direct commit execution;
+- editor-based commit execution.
+
+That makes the core loop easy to test without running real git/editor processes. Unit tests should cover:
+
+- first-draft accept;
+- regenerate followed by accept;
+- regenerate followed by abort;
+- edit success;
+- edit failure;
+- non-interactive guard behavior;
+- deprecated alias messaging;
+- clipboard migration errors.
+
+For interactive CLI tests, `CliRunner.invoke(..., input=...)` is sufficient for menu-driven review flows. Regenerate loops can be tested by making the mock generator return a sequence of drafts.
+
+#### Integration tests
+
+Use the existing temporary git repository pattern from `tests/integration/test_cli.py`.
+
+Recommended integration techniques:
+
+- **accept / `--yes`**: run against a real repo, then inspect `git log -1 --pretty=%B`;
+- **abort**: verify `git rev-list --count HEAD` is unchanged;
+- **regenerate**: mock the generator with sequential messages and verify the committed message is the later draft;
+- **edit success**: set `GIT_EDITOR` to a tiny Python script in the temp directory that rewrites the commit message file and exits `0`;
+- **edit failure**: set `GIT_EDITOR` to a script that exits non-zero;
+- **non-interactive guard**: invoke in a non-TTY context and assert the command exits quickly with migration guidance.
+
+Using a Python script for `GIT_EDITOR` is more portable than shell snippets and works across Linux, macOS, and Windows test environments.
+
+### 5. Completion/runtime contract
+
+The completion helper must stay on the raw generation path.
+
+Recommended invariant:
+
+- `gmuse git-completions-run` must continue to gather context and call `generate_message()` directly, or call a shared raw-generation helper that does the same thing;
+- it must never import or invoke the interactive commit-session review loop;
+- it must keep emitting JSON on stdout with the existing status contract.
+
+Implementation guidance:
+
+- if command code is refactored, extract a shared raw-generation helper that returns a message/result object and let both `generate` and `git-completions-run` call that helper;
+- keep completion-specific timeout handling and JSON status mapping inside `src/gmuse/cli/completions.py`;
+- keep the existing stderr-suppression behavior for completion runs so debug logs do not corrupt JSON output.
+
+Regression coverage should assert that completion execution still:
+
+- returns JSON only;
+- bypasses commit prompts and editor launch paths;
+- ignores retired clipboard behavior;
+- preserves timeout/offline/no-staged-changes status mapping.
+
+## Phase 1 implications
+
+The next phase should encode these decisions into:
+
+- a commit-session data model with explicit outcomes (`committed`, `aborted`, `failed`);
+- a CLI contract that distinguishes `commit`, `generate`, and deprecated `msg`;
+- a completion contract that documents the preserved raw path;
+- a quickstart that treats clipboard behavior as migration-only, not as a supported destination UX.

--- a/specs/008-commit-ux-redesign/spec.md
+++ b/specs/008-commit-ux-redesign/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Breaking CLI UX Redesign for Commit Message Generation
+
+**Feature Branch**: `008-commit-ux-redesign`
+**Created**: 2026-06-06
+**Status**: Draft
+**Input**: User description: "Create a new feature spec in this repository for a breaking CLI UX redesign around commit message generation."
+
+---
+
+## Clarifications & Migration Decisions
+
+- **Primary workflow**: `gmuse commit` becomes the primary, documented way to generate a message and immediately use it for a git commit.
+- **Raw generation primitive**: `gmuse generate` becomes the stdout-only command for scripts, shell integration, and completion plumbing.
+- **Interactive default**: `gmuse commit` defaults to an interactive review flow so users can inspect the generated message before a commit is finalized.
+- **Fast path**: `gmuse commit --yes` skips the interactive review flow and commits immediately with the first generated draft.
+- **Legacy command**: `gmuse msg` becomes a deprecated compatibility alias for `gmuse generate` for one transitional release line after this redesign ships. During that period it must emit actionable migration guidance. Removal before 1.0 is allowed after that transition.
+- **Clipboard direction**: Clipboard support is no longer part of the primary product UX. New command surfaces do not center or require clipboard behavior.
+- **`--copy` fate**: `--copy` is removed from the primary workflow. If users invoke `gmuse msg --copy` during the transition period, the command must fail with a clear migration message pointing users to `gmuse commit` for direct commits or `gmuse generate` plus their own shell clipboard tooling if they still want copy-based workflows.
+- **Completion contract**: Shell completion behavior must continue to rely on a raw generation path or dedicated runtime helper, never on the interactive commit flow.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Review and finalize an AI-generated commit interactively (Priority: P1)
+
+As a developer with staged changes, I want `gmuse` to guide me through reviewing a generated commit message and then committing with it so I no longer need to copy text out of the terminal into a separate `git commit` step.
+
+**Why this priority**: This is the core UX change. The redesign only succeeds if the main flow removes copy/paste friction and makes review part of the commit process.
+
+**Independent Test**: With staged changes in a git repository, run `gmuse commit` in an interactive terminal and verify the user can see the generated draft, choose from review actions, and complete or cancel the commit without manually copying the message.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes and an interactive terminal, **When** the user runs `gmuse commit`, **Then** the command generates a draft commit message, shows it for review, and presents accept, edit, regenerate, and abort choices before any commit is finalized.
+2. **Given** a reviewed draft, **When** the user chooses accept, **Then** the system creates the git commit using that reviewed message and reports success.
+3. **Given** a reviewed draft, **When** the user chooses edit, **Then** the system opens the user's normal commit authoring flow with the generated draft prefilled so the user can revise it before finalizing.
+4. **Given** a reviewed draft, **When** the user chooses regenerate, **Then** the system replaces the current draft with a newly generated draft and returns to the same review step.
+5. **Given** a reviewed draft, **When** the user chooses abort, **Then** no git commit is created and the command exits clearly without ambiguity about the outcome.
+
+---
+
+### User Story 2 - Commit immediately when I trust the generated draft (Priority: P1)
+
+As a developer who wants the fastest possible flow, I want a non-interactive confirmation flag so I can generate and commit in one step when I do not need manual review.
+
+**Why this priority**: The redesign should make the main UX better without removing an efficient path for experienced users and automation-friendly personal workflows.
+
+**Independent Test**: With staged changes in a git repository, run `gmuse commit --yes` and verify the command creates a commit directly from the first generated draft without prompting for review.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes, **When** the user runs `gmuse commit --yes`, **Then** the system generates a draft and immediately creates the git commit with that message without prompting.
+2. **Given** a non-interactive environment, **When** the user runs `gmuse commit --yes`, **Then** the command can still complete successfully because it does not require an interactive prompt or editor.
+
+---
+
+### User Story 3 - Use raw generation for scripts and shell completion plumbing (Priority: P1)
+
+As a developer or tool author, I want a raw stdout-only command so scripting, shell completions, and other integrations can keep using generated commit text without triggering an interactive commit workflow.
+
+**Why this priority**: The redesign must preserve automation and completion support while separating message generation from the act of committing.
+
+**Independent Test**: Run `gmuse generate` in a repository with staged changes and verify the command outputs only the generated commit message to stdout, with no review prompts, clipboard handling, or git commit side effects.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes, **When** the user runs `gmuse generate`, **Then** the command writes only the generated commit message to stdout and exits successfully without creating a commit.
+2. **Given** an existing shell completion integration, **When** completion requests a generated message, **Then** it continues to use a raw generation path or runtime helper and never triggers the interactive `gmuse commit` UX.
+3. **Given** a scripted workflow that pipes output from `gmuse generate`, **When** the command succeeds, **Then** the stdout stream contains only the commit message content needed by the script.
+
+---
+
+### User Story 4 - Understand and migrate from the old command surface (Priority: P2)
+
+As an existing `gmuse` user, I want the renamed commands, deprecated aliases, and removed clipboard-centric behavior to be explained clearly so I can update my habits and scripts without confusion.
+
+**Why this priority**: This redesign is intentionally breaking. Discoverability and migration guidance are required to prevent avoidable frustration.
+
+**Independent Test**: Run help commands and legacy commands (`gmuse msg`, `gmuse msg --copy`) and verify the user is told what changed, what replacement command to use, and whether compatibility is temporary.
+
+**Acceptance Scenarios**:
+
+1. **Given** the redesign has shipped, **When** the user runs `gmuse --help` or relevant subcommand help, **Then** `gmuse commit` is presented as the primary workflow and `gmuse generate` as the raw primitive.
+2. **Given** a user runs `gmuse msg`, **When** the compatibility alias is still within its supported transition window, **Then** the command behaves like `gmuse generate` and emits a deprecation notice with the replacement command.
+3. **Given** a user runs `gmuse msg --copy`, **When** the redesign is active, **Then** the command exits with a clear migration error that explains clipboard-first behavior is retired and points to supported alternatives.
+
+---
+
+### Edge Cases
+
+- Running `gmuse commit` in a non-interactive terminal without `--yes` must not hang waiting for input; it should fail with guidance to use `--yes` or `gmuse generate`.
+- If there are no staged changes, all affected commands must fail clearly without creating a commit or opening an editor.
+- If generation succeeds but the final git commit is rejected by git hooks or other commit-time validation, the user must receive a clear failure outcome and no false success message.
+- If the user selects edit but the editor cannot be opened, the command must report the problem and leave the repository uncommitted.
+- If the user exits the editor without saving a usable commit message, the command must treat that as a non-commit outcome rather than silently committing an empty or unintended message.
+- Multi-line commit messages must preserve subject/body structure across interactive review, editor handoff, raw stdout generation, and the fast path.
+- Completion-triggered generation must never surface interactive prompts, editor launches, or clipboard-oriented behavior.
+- Legacy scripts that still call `gmuse msg` during the transition must receive deterministic behavior and deterministic deprecation messaging.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST provide `gmuse commit` as the primary documented command for generating a commit message and using it to create a git commit.
+- **FR-002**: `gmuse commit` MUST default to an interactive review flow when standard input and output are interactive.
+- **FR-003**: The interactive review flow MUST show the generated draft before finalizing the commit and MUST offer accept, edit, regenerate, and abort actions.
+- **FR-004**: If the user chooses accept, the system MUST create the git commit using the currently reviewed draft message.
+- **FR-005**: If the user chooses edit, the system MUST hand off the generated draft to the user's normal commit authoring flow so the user can revise the final message before commit completion.
+- **FR-006**: If the user chooses regenerate, the system MUST generate a replacement draft and return the user to the review step without creating a commit from the previous draft.
+- **FR-007**: If the user chooses abort, the system MUST exit without creating a git commit.
+- **FR-008**: The CLI MUST provide a non-interactive fast path such that `gmuse commit --yes` generates one draft and immediately uses it for the git commit without a review prompt.
+- **FR-009**: If `gmuse commit` is invoked without an interactive terminal and without `--yes`, the command MUST fail with an actionable message directing users to `gmuse commit --yes` or `gmuse generate`.
+- **FR-010**: The CLI MUST provide `gmuse generate` as the raw generation command for scripting, shell integration, and completion plumbing.
+- **FR-011**: `gmuse generate` MUST write only the generated commit message to stdout on success and MUST NOT open an editor, prompt for review, create a commit, or depend on clipboard behavior.
+- **FR-012**: Shell/tab completion support MUST continue to work after the redesign, and completion flows MUST remain based on a raw generation path or dedicated runtime helper rather than the interactive commit command.
+- **FR-013**: `gmuse msg` MUST become a deprecated compatibility alias for `gmuse generate` for one transitional release line after the redesign is introduced.
+- **FR-014**: During the compatibility window, `gmuse msg` MUST emit a deprecation notice that names `gmuse generate` as the replacement for raw output use cases and `gmuse commit` as the replacement for direct commit workflows.
+- **FR-015**: `--copy` MUST NOT be part of the primary `gmuse commit` or `gmuse generate` command surfaces.
+- **FR-016**: If a user invokes legacy clipboard behavior such as `gmuse msg --copy`, the command MUST fail with a clear migration message explaining that clipboard-first behavior is retired and that stdout piping or the direct commit flow are the supported alternatives.
+- **FR-017**: All affected commands MUST preserve existing core commit-message-shaping inputs that remain in scope for generation, including message format options and other established context inputs, unless a separate breaking change explicitly removes them.
+- **FR-018**: All affected commands MUST preserve current prerequisite validation and error behavior for unsupported contexts such as not being in a git repository, having no staged changes, or lacking required generation credentials.
+- **FR-019**: Help text, command descriptions, and user-facing documentation MUST present `gmuse commit` as the main workflow, `gmuse generate` as the scripting/completion primitive, and the `gmuse msg` transition policy clearly.
+- **FR-020**: The redesign MUST make review possible before commit finalization in the default interactive path, while still allowing explicit user opt-out via `--yes`.
+
+### Key Entities *(include if feature involves data)*
+
+- **Generated Draft**: A proposed commit message produced from the current staged changes and relevant generation inputs. It may contain a subject line only or a subject and body.
+- **Commit Session**: A single user interaction with `gmuse commit`, including draft generation, review actions, optional editing, and either successful commit completion or explicit cancellation/failure.
+- **Raw Generation Output**: The stdout-only message emitted by `gmuse generate` or equivalent completion plumbing for use by scripts and shell integrations.
+- **Migration Notice**: User-facing guidance emitted when a deprecated command or removed flag is used, including the supported replacement path.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, at least 90% of representative users can complete a commit with `gmuse commit` in under 30 seconds without manual copy/paste between commands.
+- **SC-002**: In 100% of default interactive `gmuse commit` sessions, users are given an opportunity to review the generated draft before any commit is finalized.
+- **SC-003**: In 100% of successful `gmuse generate` runs, stdout contains only the generated commit message content needed by scripts and completion plumbing.
+- **SC-004**: At least 95% of completion-triggered raw generation requests either return a usable suggestion or fail cleanly within the configured completion timeout, with no interactive prompt or editor launch.
+- **SC-005**: In migration validation, all deprecated entry points and removed clipboard workflows produce actionable guidance that names the correct replacement command.
+
+---
+
+## Assumptions
+
+- The project is still pre-1.0, so a breaking change to the primary CLI UX is acceptable if migration behavior is clearly documented.
+- The redesign changes how users reach commit generation and commit execution, but it does not expand scope into staging, amend workflows, or broader git history editing.
+- Users who choose the edit path have a working commit authoring environment available through their normal git/editor configuration.
+- Existing shell completion behavior continues to rely on a raw generation runtime path and should remain decoupled from any interactive commit UX.
+- Clipboard-specific workflows are considered optional personal shell behavior rather than a core responsibility of `gmuse`.
+

--- a/specs/008-commit-ux-redesign/spec.md
+++ b/specs/008-commit-ux-redesign/spec.md
@@ -12,6 +12,7 @@
 - **Primary workflow**: `gmuse commit` becomes the primary, documented way to generate a message and immediately use it for a git commit.
 - **Raw generation primitive**: `gmuse generate` becomes the stdout-only command for scripts, shell integration, and completion plumbing.
 - **Interactive default**: `gmuse commit` defaults to an interactive review flow so users can inspect the generated message before a commit is finalized.
+- **Edit-first path**: `gmuse commit --edit` generates one draft, immediately opens the user's normal commit editor with that draft prefilled, and commits after the editor exits.
 - **Fast path**: `gmuse commit --yes` skips the interactive review flow and commits immediately with the first generated draft.
 - **Legacy command**: `gmuse msg` becomes a deprecated compatibility alias for `gmuse generate` for one transitional release line after this redesign ships. During that period it must emit actionable migration guidance. Removal before 1.0 is allowed after that transition.
 - **Clipboard direction**: Clipboard support is no longer part of the primary product UX. New command surfaces do not center or require clipboard behavior.
@@ -55,7 +56,24 @@ As a developer who wants the fastest possible flow, I want a non-interactive con
 
 ---
 
-### User Story 3 - Use raw generation for scripts and shell completion plumbing (Priority: P1)
+### User Story 3 - Edit the generated draft immediately (Priority: P1)
+
+As a developer who usually wants to polish generated messages in my normal editor, I want a flag that skips the review prompt and opens the generated draft for editing immediately.
+
+**Why this priority**: This preserves user control while reducing steps for developers who consistently prefer editor-based commit authoring over menu-based review.
+
+**Independent Test**: With staged changes in a git repository and a working commit editor, run `gmuse commit --edit` and verify the command generates one draft, opens the editor with that draft prefilled, and creates or aborts the commit according to the edited message.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes and an interactive terminal, **When** the user runs `gmuse commit --edit`, **Then** the system generates a draft and opens the user's normal commit authoring flow immediately without showing the review action prompt.
+2. **Given** the editor opens with the generated draft, **When** the user saves a usable message and exits, **Then** the system creates the git commit with the edited message.
+3. **Given** the editor opens with the generated draft, **When** the user exits with no usable commit message, **Then** no git commit is created and the command reports that the commit was aborted.
+4. **Given** the user runs `gmuse commit --edit --yes`, **When** the command validates the request, **Then** it fails with a usage error because edit-first and commit-immediately are conflicting modes.
+
+---
+
+### User Story 4 - Use raw generation for scripts and shell completion plumbing (Priority: P1)
 
 As a developer or tool author, I want a raw stdout-only command so scripting, shell completions, and other integrations can keep using generated commit text without triggering an interactive commit workflow.
 
@@ -71,7 +89,7 @@ As a developer or tool author, I want a raw stdout-only command so scripting, sh
 
 ---
 
-### User Story 4 - Understand and migrate from the old command surface (Priority: P2)
+### User Story 5 - Understand and migrate from the old command surface (Priority: P2)
 
 As an existing `gmuse` user, I want the renamed commands, deprecated aliases, and removed clipboard-centric behavior to be explained clearly so I can update my habits and scripts without confusion.
 
@@ -90,6 +108,8 @@ As an existing `gmuse` user, I want the renamed commands, deprecated aliases, an
 ### Edge Cases
 
 - Running `gmuse commit` in a non-interactive terminal without `--yes` must not hang waiting for input; it should fail with guidance to use `--yes` or `gmuse generate`.
+- Running `gmuse commit --edit` in a non-interactive terminal must fail rather than launching an editor or hanging.
+- Running `gmuse commit --edit --yes` must fail as an invalid combination because one mode requires editor review while the other commits immediately.
 - If there are no staged changes, all affected commands must fail clearly without creating a commit or opening an editor.
 - If generation succeeds but the final git commit is rejected by git hooks or other commit-time validation, the user must receive a clear failure outcome and no false success message.
 - If the user selects edit but the editor cannot be opened, the command must report the problem and leave the repository uncommitted.
@@ -112,18 +132,20 @@ As an existing `gmuse` user, I want the renamed commands, deprecated aliases, an
 - **FR-006**: If the user chooses regenerate, the system MUST generate a replacement draft and return the user to the review step without creating a commit from the previous draft.
 - **FR-007**: If the user chooses abort, the system MUST exit without creating a git commit.
 - **FR-008**: The CLI MUST provide a non-interactive fast path such that `gmuse commit --yes` generates one draft and immediately uses it for the git commit without a review prompt.
-- **FR-009**: If `gmuse commit` is invoked without an interactive terminal and without `--yes`, the command MUST fail with an actionable message directing users to `gmuse commit --yes` or `gmuse generate`.
-- **FR-010**: The CLI MUST provide `gmuse generate` as the raw generation command for scripting, shell integration, and completion plumbing.
-- **FR-011**: `gmuse generate` MUST write only the generated commit message to stdout on success and MUST NOT open an editor, prompt for review, create a commit, or depend on clipboard behavior.
-- **FR-012**: Shell/tab completion support MUST continue to work after the redesign, and completion flows MUST remain based on a raw generation path or dedicated runtime helper rather than the interactive commit command.
-- **FR-013**: `gmuse msg` MUST become a deprecated compatibility alias for `gmuse generate` for one transitional release line after the redesign is introduced.
-- **FR-014**: During the compatibility window, `gmuse msg` MUST emit a deprecation notice that names `gmuse generate` as the replacement for raw output use cases and `gmuse commit` as the replacement for direct commit workflows.
-- **FR-015**: `--copy` MUST NOT be part of the primary `gmuse commit` or `gmuse generate` command surfaces.
-- **FR-016**: If a user invokes legacy clipboard behavior such as `gmuse msg --copy`, the command MUST fail with a clear migration message explaining that clipboard-first behavior is retired and that stdout piping or the direct commit flow are the supported alternatives.
-- **FR-017**: All affected commands MUST preserve existing core commit-message-shaping inputs that remain in scope for generation, including message format options and other established context inputs, unless a separate breaking change explicitly removes them.
-- **FR-018**: All affected commands MUST preserve current prerequisite validation and error behavior for unsupported contexts such as not being in a git repository, having no staged changes, or lacking required generation credentials.
-- **FR-019**: Help text, command descriptions, and user-facing documentation MUST present `gmuse commit` as the main workflow, `gmuse generate` as the scripting/completion primitive, and the `gmuse msg` transition policy clearly.
-- **FR-020**: The redesign MUST make review possible before commit finalization in the default interactive path, while still allowing explicit user opt-out via `--yes`.
+- **FR-009**: The CLI MUST provide an edit-first path such that `gmuse commit --edit` generates one draft, opens the user's normal commit authoring flow with that draft prefilled, and creates the commit only after the editor exits with a usable message.
+- **FR-010**: `gmuse commit --edit` and `gmuse commit --yes` MUST be mutually exclusive.
+- **FR-011**: If `gmuse commit` is invoked without an interactive terminal and without `--yes`, the command MUST fail with an actionable message directing users to `gmuse commit --yes` or `gmuse generate`.
+- **FR-012**: The CLI MUST provide `gmuse generate` as the raw generation command for scripting, shell integration, and completion plumbing.
+- **FR-013**: `gmuse generate` MUST write only the generated commit message to stdout on success and MUST NOT open an editor, prompt for review, create a commit, or depend on clipboard behavior.
+- **FR-014**: Shell/tab completion support MUST continue to work after the redesign, and completion flows MUST remain based on a raw generation path or dedicated runtime helper rather than the interactive commit command.
+- **FR-015**: `gmuse msg` MUST become a deprecated compatibility alias for `gmuse generate` for one transitional release line after the redesign is introduced.
+- **FR-016**: During the compatibility window, `gmuse msg` MUST emit a deprecation notice that names `gmuse generate` as the replacement for raw output use cases and `gmuse commit` as the replacement for direct commit workflows.
+- **FR-017**: `--copy` MUST NOT be part of the primary `gmuse commit` or `gmuse generate` command surfaces.
+- **FR-018**: If a user invokes legacy clipboard behavior such as `gmuse msg --copy`, the command MUST fail with a clear migration message explaining that clipboard-first behavior is retired and that stdout piping or the direct commit flow are the supported alternatives.
+- **FR-019**: All affected commands MUST preserve existing core commit-message-shaping inputs that remain in scope for generation, including message format options and other established context inputs, unless a separate breaking change explicitly removes them.
+- **FR-020**: All affected commands MUST preserve current prerequisite validation and error behavior for unsupported contexts such as not being in a git repository, having no staged changes, or lacking required generation credentials.
+- **FR-021**: Help text, command descriptions, and user-facing documentation MUST present `gmuse commit` as the main workflow, `gmuse generate` as the scripting/completion primitive, and the `gmuse msg` transition policy clearly.
+- **FR-022**: The redesign MUST make review possible before commit finalization in the default interactive path, while still allowing explicit alternate modes via `--edit` and `--yes`.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/008-commit-ux-redesign/spec.md
+++ b/specs/008-commit-ux-redesign/spec.md
@@ -153,4 +153,3 @@ As an existing `gmuse` user, I want the renamed commands, deprecated aliases, an
 - Users who choose the edit path have a working commit authoring environment available through their normal git/editor configuration.
 - Existing shell completion behavior continues to rely on a raw generation runtime path and should remain decoupled from any interactive commit UX.
 - Clipboard-specific workflows are considered optional personal shell behavior rather than a core responsibility of `gmuse`.
-

--- a/specs/008-commit-ux-redesign/tasks.md
+++ b/specs/008-commit-ux-redesign/tasks.md
@@ -1,0 +1,235 @@
+# Tasks: Breaking CLI UX Redesign for Commit Message Generation
+
+**Input**: Design documents from `/specs/008-commit-ux-redesign/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cli-commands.md`, `contracts/completion-runtime.md`, `quickstart.md`
+
+**Tests**: This feature requires unit, integration, lint, type, and docs validation using the existing pytest/nox workflow.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently once Phase 2 is complete.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete-task dependency)
+- **[Story]**: User story label (`[US1]`, `[US2]`, `[US3]`, `[US4]`)
+- Every task includes concrete repository file paths
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the new module/test/doc touchpoints needed for the redesign without changing behavior yet.
+
+- [ ] T001 Create commit workflow scaffolding in src/gmuse/cli/commit_session.py, tests/unit/test_cli_commit_session.py, and tests/integration/test_cli_generate_commit.py
+- [ ] T002 [P] Add command-surface baseline assertions for renamed CLI help in tests/unit/test_cli_main.py and tests/unit/test_cli_main_additional.py
+- [ ] T003 [P] Add reusable git/editor test helpers for commit-flow integration coverage in tests/integration/test_cli.py and tests/integration/test_cli_generate_commit.py
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared raw-generation and commit-execution boundaries that every story depends on.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Extract a shared raw-generation request/result helper from src/gmuse/cli/main.py into src/gmuse/commit.py and src/gmuse/cli/config_resolution.py so commit, generate, msg, and completions share one generation path
+- [ ] T005 [P] Add commit-session, migration, and non-interactive CLI error types in src/gmuse/exceptions.py and map them in src/gmuse/cli/main.py
+- [ ] T006 [P] Add direct commit, editor handoff, and HEAD-change git wrappers in src/gmuse/git.py for accept/edit/--yes outcomes
+- [ ] T007 [P] Deprecate clipboard compatibility inputs in src/gmuse/config.py and src/gmuse/cli/config_resolution.py so GMUSE_COPY and copy_to_clipboard stay inert on raw/completion success paths
+- [ ] T008 Preserve the raw completion boundary in src/gmuse/cli/completions.py by reusing the shared generation helper without importing src/gmuse/cli/commit_session.py
+
+**Checkpoint**: Shared generation, git commit wrappers, and compatibility/error plumbing are ready for story work.
+
+---
+
+## Phase 3: User Story 1 - Review and finalize an AI-generated commit interactively (Priority: P1) 🎯 MVP
+
+**Goal**: Make `gmuse commit` the primary interactive workflow with accept, edit, regenerate, and abort actions before any commit is finalized.
+
+**Independent Test**: In a repo with staged changes, run `gmuse commit` in an interactive terminal and verify accept, edit, regenerate, and abort all behave correctly without manual copy/paste.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE**: Write these tests first and confirm they fail before implementation.
+
+- [ ] T009 [P] [US1] Add unit tests for accept/edit/regenerate/abort review-loop branches in tests/unit/test_cli_commit_session.py
+- [ ] T010 [P] [US1] Add integration tests for interactive accept/edit/regenerate/abort flows in tests/integration/test_cli_generate_commit.py
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Implement CommitSession, GeneratedDraft tracking, and review-action orchestration in src/gmuse/cli/commit_session.py
+- [ ] T012 [US1] Add the interactive gmuse commit command, draft rendering, and action prompt wiring in src/gmuse/cli/main.py
+- [ ] T013 [US1] Surface accept/edit success and failure outcomes consistently in src/gmuse/cli/commit_session.py and src/gmuse/git.py
+
+**Checkpoint**: `gmuse commit` interactive review works end-to-end and is independently testable.
+
+---
+
+## Phase 4: User Story 2 - Commit immediately when I trust the generated draft (Priority: P1)
+
+**Goal**: Support `gmuse commit --yes` as the explicit fast path and fail fast when interactive review would hang in non-interactive environments.
+
+**Independent Test**: Run `gmuse commit --yes` with staged changes and verify it commits immediately; run `gmuse commit` without TTYs and verify it exits with guidance instead of prompting.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T014 [P] [US2] Add unit tests for `gmuse commit --yes`, `gmuse commit --dry-run` rejection, and the non-interactive guard in tests/unit/test_cli_main.py and tests/unit/test_cli_commit_session.py
+- [ ] T015 [P] [US2] Add integration tests for `gmuse commit --yes` success and non-interactive `gmuse commit` failure guidance in tests/integration/test_cli_generate_commit.py
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Implement the `--yes` fast path and reject raw-only options on commit in src/gmuse/cli/main.py and src/gmuse/cli/commit_session.py
+- [ ] T017 [US2] Enforce non-interactive guard messaging and exit behavior in src/gmuse/cli/main.py and src/gmuse/exceptions.py
+
+**Checkpoint**: The fast path works without prompts, and non-interactive `gmuse commit` no longer risks hanging.
+
+---
+
+## Phase 5: User Story 3 - Use raw generation for scripts and shell completion plumbing (Priority: P1)
+
+**Goal**: Expose `gmuse generate` as the stdout-only primitive while keeping `gmuse git-completions-run` on the same raw generation path.
+
+**Independent Test**: Run `gmuse generate` and verify stdout contains only the commit message; run `gmuse git-completions-run` and verify stdout remains JSON-only without any interactive commit behavior.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T018 [P] [US3] Add unit tests for shared raw-generation option plumbing and completion invariants in tests/unit/test_cli_main.py, tests/unit/test_commit.py, and tests/unit/test_cli_completions.py
+- [ ] T019 [P] [US3] Add integration tests for stdout-only `gmuse generate` and JSON-only `gmuse git-completions-run` behavior in tests/integration/test_cli_generate_commit.py and tests/integration/test_completions_run.py
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Add the `gmuse generate` command and shared stdout-only execution helper in src/gmuse/cli/main.py and src/gmuse/commit.py
+- [ ] T021 [US3] Route completion runtime through the shared raw-generation helper while preserving timeout/status mapping in src/gmuse/cli/completions.py
+- [ ] T022 [US3] Update command ordering and raw-generation help text in src/gmuse/cli/main.py and docs/source/development/shell-completions.md
+
+**Checkpoint**: Scripts and completions use the raw path only, with no commit/editor/clipboard side effects.
+
+---
+
+## Phase 6: User Story 4 - Understand and migrate from the old command surface (Priority: P2)
+
+**Goal**: Provide a clear migration path from `gmuse msg` and retired clipboard behavior to `gmuse generate` and `gmuse commit`.
+
+**Independent Test**: Verify `gmuse --help`, `gmuse msg`, and `gmuse msg --copy` clearly describe the new command split, deprecation window, and retired clipboard workflow.
+
+### Tests for User Story 4 ⚠️
+
+- [ ] T023 [P] [US4] Add unit tests for deprecated `gmuse msg`, `gmuse msg --copy`, and passive clipboard compatibility handling in tests/unit/test_cli_main.py and tests/unit/test_config.py
+- [ ] T024 [P] [US4] Add integration tests for `gmuse msg` deprecation stderr, `gmuse msg --copy` migration errors, and ignored clipboard compatibility inputs in tests/integration/test_cli_generate_commit.py and tests/integration/test_completions_run.py
+
+### Implementation for User Story 4
+
+- [ ] T025 [US4] Convert `gmuse msg` into a deprecated alias for `gmuse generate` and remove `--copy` from primary command surfaces in src/gmuse/cli/main.py
+- [ ] T026 [US4] Implement retired clipboard migration behavior for GMUSE_COPY and copy_to_clipboard in src/gmuse/config.py, src/gmuse/cli/config_resolution.py, and src/gmuse/exceptions.py
+- [ ] T027 [US4] Update migration guidance in README.md, docs/source/reference/cli.md, docs/source/reference/configuration.md, docs/source/tutorials/quickstart.md, docs/source/how_to/completions.md, docs/source/how_to/troubleshooting.md, and docs/source/explanation/how_it_works.md
+
+**Checkpoint**: Legacy entry points are still understandable, but users are guided firmly to the new workflow.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final docs alignment, scenario validation, and repository quality checks across all stories.
+
+- [ ] T028 [P] Refresh primary workflow and migration examples in docs/source/reference/cli.md, docs/source/how_to/configuration.md, docs/source/how_to/completions.md, docs/source/tutorials/quickstart.md, and README.md
+- [ ] T029 Validate the feature walkthrough against specs/008-commit-ux-redesign/quickstart.md and keep end-to-end examples aligned in tests/integration/test_cli_generate_commit.py
+- [ ] T030 Run `uv run nox -s test`, `uv run nox -s lint`, `uv run nox -s types`, and `uv run nox -s docs` for the changes governed by noxfile.py
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup** — no dependencies
+- **Phase 2: Foundational** — depends on Phase 1 and blocks all user stories
+- **Phase 3: US1** — depends on Phase 2
+- **Phase 4: US2** — depends on Phase 2 and benefits from US1 command wiring
+- **Phase 5: US3** — depends on Phase 2 and must preserve the raw-generation boundary introduced there
+- **Phase 6: US4** — depends on Phases 3-5 because aliasing and migration text must reflect the finished command surfaces
+- **Phase 7: Polish** — depends on all selected user stories being complete
+
+### User Story Dependencies
+
+- **US1**: Starts after Foundational and delivers the MVP interactive commit flow
+- **US2**: Starts after Foundational; shares `gmuse commit` plumbing with US1 but remains independently testable through `--yes` and non-interactive failure behavior
+- **US3**: Starts after Foundational; depends on the shared raw helper, not on interactive commit orchestration
+- **US4**: Starts after the command surfaces from US1-US3 are stable enough to document and deprecate
+
+### Within Each User Story
+
+- Tests first, and they must fail before implementation
+- Shared command/helper plumbing before story-specific help/docs updates
+- Git/editor outcome handling before success messaging
+- Complete one story end-to-end before counting it as done
+
+---
+
+## Parallel Opportunities
+
+- **Phase 1**: T002 and T003 can run in parallel after T001 creates the new file touchpoints
+- **Phase 2**: T005, T006, T007, and T008 can run in parallel after T004 defines the shared raw-generation seam
+- **US1**: T009 and T010 can run together; T011 and T013 can overlap once the session structure exists
+- **US2**: T014 and T015 can run together before T016 and T017
+- **US3**: T018 and T019 can run together; T021 and T022 can proceed after T020 establishes `gmuse generate`
+- **US4**: T023 and T024 can run together; T027 can start once T025 defines the final alias/help behavior
+- **Polish**: T028 and T029 can run in parallel before T030 executes the full nox validation suite
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write failing coverage for the review loop in parallel:
+Task: "T009 Add unit tests for accept/edit/regenerate/abort review-loop branches in tests/unit/test_cli_commit_session.py"
+Task: "T010 Add integration tests for interactive accept/edit/regenerate/abort flows in tests/integration/test_cli_generate_commit.py"
+
+# After the session model exists, implementation can split cleanly:
+Task: "T011 Implement CommitSession, GeneratedDraft tracking, and review-action orchestration in src/gmuse/cli/commit_session.py"
+Task: "T013 Surface accept/edit success and failure outcomes consistently in src/gmuse/cli/commit_session.py and src/gmuse/git.py"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Protect the raw path before changing command wiring:
+Task: "T018 Add unit tests for shared raw-generation option plumbing and completion invariants in tests/unit/test_cli_main.py, tests/unit/test_commit.py, and tests/unit/test_cli_completions.py"
+Task: "T019 Add integration tests for stdout-only gmuse generate and JSON-only gmuse git-completions-run behavior in tests/integration/test_cli_generate_commit.py and tests/integration/test_completions_run.py"
+
+# Once generate exists, completion and docs can move independently:
+Task: "T021 Route completion runtime through the shared raw-generation helper while preserving timeout/status mapping in src/gmuse/cli/completions.py"
+Task: "T022 Update command ordering and raw-generation help text in src/gmuse/cli/main.py and docs/source/development/shell-completions.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2
+2. Deliver Phase 3 (`gmuse commit` interactive review flow)
+3. Validate accept/edit/regenerate/abort independently
+4. Stop and demo before expanding to `--yes`, `generate`, and migration work
+
+### Incremental Delivery
+
+1. Setup + Foundational establish the shared raw path and commit wrappers
+2. Add US1 for the new primary workflow
+3. Add US2 for trusted fast-path and non-interactive safety
+4. Add US3 for scripting/completion preservation
+5. Add US4 for migration, aliasing, and clipboard retirement
+6. Finish with docs and nox validation
+
+### Suggested Team Split
+
+1. One developer owns Phase 2 shared helpers (`src/gmuse/commit.py`, `src/gmuse/git.py`, `src/gmuse/exceptions.py`)
+2. One developer owns `gmuse commit` session UX (`src/gmuse/cli/main.py`, `src/gmuse/cli/commit_session.py`, US1-US2 tests)
+3. One developer owns raw path + migration docs (`src/gmuse/cli/completions.py`, README.md, docs/source/, US3-US4 tests)
+
+---
+
+## Notes
+
+- `gmuse commit` and `gmuse generate` must remain separate orchestration layers even when they reuse the same raw-generation helper
+- `gmuse git-completions-run` must stay JSON-only and must never import or execute interactive commit-session logic
+- `gmuse msg` is temporary compatibility only; migration guidance belongs on stderr, not stdout
+- Passive clipboard compatibility inputs must never violate the stdout-only success contract of `gmuse generate`

--- a/src/gmuse/cli/commit_session.py
+++ b/src/gmuse/cli/commit_session.py
@@ -1,0 +1,93 @@
+"""Interactive commit session orchestration.
+
+Provides a small review loop for generated commit drafts with actions:
+- accept: create commit from draft
+- edit: open user's editor with draft prefilled
+- regenerate: request a fresh draft from the generation function
+- abort: exit without committing
+
+This module is intentionally minimal and testable: side effects (git commit / editor
+invocation) are delegated to gmuse.git helpers so they can be mocked in tests.
+"""
+from typing import Callable, Optional
+import tempfile
+import sys
+
+from gmuse.git import commit_with_message, open_editor_with_message
+from gmuse.commit import MessageResult
+
+
+def run_commit_session(
+    config: dict,
+    hint: Optional[str],
+    context,
+    generate_fn: Callable[[dict, Optional[str], object], MessageResult],
+    non_interactive: bool = False,
+) -> None:
+    """Run the commit review session.
+
+    Args:
+        config: Resolved configuration dict
+        hint: Optional user hint passed to generator
+        context: Context object from gather_context
+        generate_fn: Callable that returns MessageResult when called as generate_fn(config, hint, context)
+        non_interactive: If True, accept the generated message and commit immediately
+    """
+    # First generation
+    result = generate_fn(config, hint, context)
+    message = result.message
+
+    if non_interactive:
+        # Fast path: create commit and exit
+        commit_with_message(message)
+        return
+
+    # Interactive loop
+    while True:
+        # Show current draft
+        print("\n----- DRAFT COMMIT MESSAGE -----\n")
+        print(message)
+        print("\n--------------------------------\n")
+
+        print("Actions: [a]ccept, [e]dit, [r]egenerate, [q]uit")
+        try:
+            choice = input("Choose action: ").strip().lower()
+        except EOFError:
+            # Treat EOF as abort
+            print("Input closed — aborting", file=sys.stderr)
+            return
+
+        if choice in ("a", "accept"):
+            try:
+                commit_with_message(message)
+                print("Commit created")
+                return
+            except Exception as e:
+                print(f"Failed to create commit: {e}", file=sys.stderr)
+                return
+
+        elif choice in ("e", "edit"):
+            try:
+                open_editor_with_message(message)
+                print("Editor exited — commit may have been created or aborted by git")
+                return
+            except Exception as e:
+                print(f"Failed to open editor: {e}", file=sys.stderr)
+                return
+
+        elif choice in ("r", "regenerate"):
+            try:
+                result = generate_fn(config, hint, context)
+                message = result.message
+                continue
+            except Exception as e:
+                print(f"Regeneration failed: {e}", file=sys.stderr)
+                return
+
+        elif choice in ("q", "quit", "abort"):
+            print("Aborted — no commit created", file=sys.stderr)
+            return
+
+        else:
+            print("Unrecognized action. Choose one of: a, e, r, q")
+            continue

--- a/src/gmuse/cli/commit_session.py
+++ b/src/gmuse/cli/commit_session.py
@@ -11,11 +11,24 @@ editor invocation) are delegated to gmuse.git helpers so they can be mocked in
 tests.
 """
 
+import subprocess
 import sys
-from typing import Callable, Optional
+from typing import Callable, NoReturn, Optional
+
+import typer
 
 from gmuse.commit import GenerationContext, GenerationResult
-from gmuse.git import commit_with_message, open_editor_with_message
+from gmuse.git import CommitOutcome, commit_with_message, open_editor_with_message
+
+
+def _exit_after_git_failure(error: subprocess.CalledProcessError) -> NoReturn:
+    """Preserve git's failure details without wrapping them in raw subprocess text."""
+    output = (error.stderr or error.stdout or "").strip()
+    if output:
+        print(output, file=sys.stderr)
+    else:
+        print("Commit failed", file=sys.stderr)
+    raise typer.Exit(code=1)
 
 
 def run_commit_session(
@@ -47,37 +60,54 @@ def run_commit_session(
     # Interactive loop
     while True:
         # Show current draft
-        print("\n----- DRAFT COMMIT MESSAGE -----\n")
-        print(message)
-        print("\n--------------------------------\n")
+        print("\nDraft commit message\n")
+        for line in message.splitlines():
+            print(f"  {line}")
+        print()
 
-        print("Actions: [a]ccept, [e]dit, [r]egenerate, [x]abort")
-        try:
-            choice = input("Choose action: ").strip().lower()
-        except EOFError:
-            # Treat EOF as abort
-            print("Input closed — aborting", file=sys.stderr)
-            return
+        print("Actions")
+        print("  a  accept")
+        print("  e  edit")
+        print("  r  regenerate")
+        print("  q  quit")
+        print()
 
-        if choice in ("a", "accept"):
-            commit_with_message(message)
-            print("Commit created")
-            return
+        while True:
+            try:
+                choice = input("Choose action: ").strip().lower()
+            except EOFError:
+                # Treat EOF as abort
+                print("Input closed - aborting", file=sys.stderr)
+                return
 
-        elif choice in ("e", "edit"):
-            open_editor_with_message(message)
-            print("Editor exited — commit may have been created or aborted by git")
-            return
+            if choice in ("a", "accept"):
+                try:
+                    commit_with_message(message)
+                except subprocess.CalledProcessError as e:
+                    _exit_after_git_failure(e)
+                print("Commit created")
+                return
 
-        elif choice in ("r", "regenerate"):
-            result = generate_fn(config, hint, context)
-            message = result.message
-            continue
+            if choice in ("e", "edit"):
+                try:
+                    outcome = open_editor_with_message(message)
+                except subprocess.CalledProcessError as e:
+                    _exit_after_git_failure(e)
+                else:
+                    if outcome is CommitOutcome.ABORTED:
+                        print("Commit aborted")
+                        return
+                    print("Commit created")
+                    return
 
-        elif choice in ("x", "abort"):
-            print("Aborted — no commit created", file=sys.stderr)
-            return
+            if choice in ("r", "regenerate"):
+                print("Regenerating commit message...")
+                result = generate_fn(config, hint, context)
+                message = result.message
+                break
 
-        else:
-            print("Unrecognized action. Choose one of: a, e, r, x")
-            continue
+            if choice in ("q", "quit"):
+                print("Commit aborted")
+                return
+
+            print("Invalid choice. Use a, e, r, or q.")

--- a/src/gmuse/cli/commit_session.py
+++ b/src/gmuse/cli/commit_session.py
@@ -6,31 +6,33 @@ Provides a small review loop for generated commit drafts with actions:
 - regenerate: request a fresh draft from the generation function
 - abort: exit without committing
 
-This module is intentionally minimal and testable: side effects (git commit / editor
-invocation) are delegated to gmuse.git helpers so they can be mocked in tests.
+This module is intentionally minimal and testable: side effects (git commit /
+editor invocation) are delegated to gmuse.git helpers so they can be mocked in
+tests.
 """
-from typing import Callable, Optional
-import tempfile
-import sys
 
+import sys
+from typing import Callable, Optional
+
+from gmuse.commit import GenerationContext, GenerationResult
 from gmuse.git import commit_with_message, open_editor_with_message
-from gmuse.commit import MessageResult
 
 
 def run_commit_session(
     config: dict,
     hint: Optional[str],
-    context,
-    generate_fn: Callable[[dict, Optional[str], object], MessageResult],
+    context: GenerationContext,
+    generate_fn: Callable[[dict, Optional[str], GenerationContext], GenerationResult],
     non_interactive: bool = False,
 ) -> None:
     """Run the commit review session.
 
     Args:
-        config: Resolved configuration dict
-        hint: Optional user hint passed to generator
-        context: Context object from gather_context
-        generate_fn: Callable that returns MessageResult when called as generate_fn(config, hint, context)
+        config: Resolved configuration dict.
+        hint: Optional user hint passed to generator.
+        context: Context object from gather_context.
+        generate_fn: Callable returning a GenerationResult when called with
+            ``(config, hint, context)``.
         non_interactive: If True, accept the generated message and commit immediately
     """
     # First generation
@@ -58,31 +60,19 @@ def run_commit_session(
             return
 
         if choice in ("a", "accept"):
-            try:
-                commit_with_message(message)
-                print("Commit created")
-                return
-            except Exception as e:
-                print(f"Failed to create commit: {e}", file=sys.stderr)
-                return
+            commit_with_message(message)
+            print("Commit created")
+            return
 
         elif choice in ("e", "edit"):
-            try:
-                open_editor_with_message(message)
-                print("Editor exited — commit may have been created or aborted by git")
-                return
-            except Exception as e:
-                print(f"Failed to open editor: {e}", file=sys.stderr)
-                return
+            open_editor_with_message(message)
+            print("Editor exited — commit may have been created or aborted by git")
+            return
 
         elif choice in ("r", "regenerate"):
-            try:
-                result = generate_fn(config, hint, context)
-                message = result.message
-                continue
-            except Exception as e:
-                print(f"Regeneration failed: {e}", file=sys.stderr)
-                return
+            result = generate_fn(config, hint, context)
+            message = result.message
+            continue
 
         elif choice in ("q", "quit", "abort"):
             print("Aborted — no commit created", file=sys.stderr)

--- a/src/gmuse/cli/commit_session.py
+++ b/src/gmuse/cli/commit_session.py
@@ -37,6 +37,7 @@ def run_commit_session(
     context: GenerationContext,
     generate_fn: Callable[[dict, Optional[str], GenerationContext], GenerationResult],
     non_interactive: bool = False,
+    edit_first: bool = False,
 ) -> None:
     """Run the commit review session.
 
@@ -47,6 +48,7 @@ def run_commit_session(
         generate_fn: Callable returning a GenerationResult when called with
             ``(config, hint, context)``.
         non_interactive: If True, accept the generated message and commit immediately
+        edit_first: If True, open the editor with the generated draft immediately.
     """
     # First generation
     result = generate_fn(config, hint, context)
@@ -56,6 +58,18 @@ def run_commit_session(
         # Fast path: create commit and exit
         commit_with_message(message)
         return
+
+    if edit_first:
+        try:
+            outcome = open_editor_with_message(message)
+        except subprocess.CalledProcessError as e:
+            _exit_after_git_failure(e)
+        else:
+            if outcome is CommitOutcome.ABORTED:
+                print("Commit aborted")
+                return
+            print("Commit created")
+            return
 
     # Interactive loop
     while True:

--- a/src/gmuse/cli/commit_session.py
+++ b/src/gmuse/cli/commit_session.py
@@ -51,7 +51,7 @@ def run_commit_session(
         print(message)
         print("\n--------------------------------\n")
 
-        print("Actions: [a]ccept, [e]dit, [r]egenerate, [q]uit")
+        print("Actions: [a]ccept, [e]dit, [r]egenerate, [x]abort")
         try:
             choice = input("Choose action: ").strip().lower()
         except EOFError:
@@ -74,10 +74,10 @@ def run_commit_session(
             message = result.message
             continue
 
-        elif choice in ("q", "quit", "abort"):
+        elif choice in ("x", "abort"):
             print("Aborted — no commit created", file=sys.stderr)
             return
 
         else:
-            print("Unrecognized action. Choose one of: a, e, r, q")
+            print("Unrecognized action. Choose one of: a, e, r, x")
             continue

--- a/src/gmuse/cli/main.py
+++ b/src/gmuse/cli/main.py
@@ -118,6 +118,7 @@ def main(
 
     Examples:
         gmuse commit                        # Review and commit
+        gmuse commit --edit                 # Generate, edit, and commit
         gmuse commit --yes                  # Generate and commit immediately
         gmuse generate                      # Print message only
         gmuse generate --format conventional  # Conventional commits
@@ -399,6 +400,11 @@ def commit(
         "-y",
         help="Non-interactive: generate and commit immediately",
     ),
+    edit: bool = typer.Option(
+        False,
+        "--edit",
+        help="Generate, open the editor with the draft, and commit",
+    ),
     model: Optional[str] = typer.Option(None, "--model", "-m"),
     format: Optional[str] = typer.Option(None, "--format", "-f"),
     history_depth: Optional[int] = typer.Option(None, "--history-depth"),
@@ -410,10 +416,14 @@ def commit(
     """Interactive commit workflow: generate, review, and create a git commit.
 
     In interactive terminals this opens a small review loop allowing accept/edit/regenerate/abort.
+    Use --edit to skip the review prompt and open the editor immediately.
     In non-interactive scripts, use --yes to generate and commit immediately.
     """
     try:
-        if not yes and (not sys.stdin.isatty() or not sys.stdout.isatty()):
+        if yes and edit:
+            _error_exit("Cannot use --yes and --edit together.", code=2)
+
+        if not yes and not _is_interactive_terminal():
             _error_exit(
                 "gmuse commit requires an interactive terminal. Use --yes for non-interactive commits or 'gmuse generate' for scripting.",
                 code=2,
@@ -446,6 +456,7 @@ def commit(
                 config=cfg, hint=h, context=ctx
             ),
             non_interactive=yes,
+            edit_first=edit,
         )
 
     except ConfigError as e:
@@ -550,6 +561,11 @@ def _load_config(
     logger.debug(f"Configuration loaded: {config}")
 
     return config
+
+
+def _is_interactive_terminal() -> bool:
+    """Return True when stdin and stdout are both attached to a TTY."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def _copy_to_clipboard(message: str) -> None:

--- a/src/gmuse/cli/main.py
+++ b/src/gmuse/cli/main.py
@@ -53,6 +53,7 @@ from gmuse.prompts import build_prompt
 from gmuse.cli.auth import auth_app
 from gmuse.cli.completions import completions_app, completions_run_command
 from gmuse.cli.config import config_app
+from gmuse.cli.commit_session import run_commit_session
 
 logger = get_logger(__name__)
 
@@ -158,18 +159,12 @@ def info() -> None:
     typer.echo(f"  GMUSE_TIMEOUT env var: {os.getenv('GMUSE_TIMEOUT')}")
 
 
-@app.command()
-def msg(
+@app.command(name="generate")
+def generate(
     hint: Optional[str] = typer.Option(
         None,
         "--hint",
         help="Additional guidance for message generation (e.g., 'emphasize security')",
-    ),
-    copy: bool = typer.Option(
-        False,
-        "--copy",
-        "-c",
-        help="Copy generated message to clipboard",
     ),
     model: Optional[str] = typer.Option(
         None,
@@ -216,26 +211,13 @@ def msg(
 ) -> None:
     """Generate a commit message from staged changes.
 
-    This command analyzes your staged git changes and generates an appropriate
-    commit message using AI. The message is printed to stdout and can optionally
-    be copied to your clipboard.
-
-    Examples:
-        gmuse msg                        # Basic usage
-        gmuse msg --hint "security fix"  # Add context hint
-        gmuse msg --format conventional  # Use conventional commits format
-        gmuse msg --copy                 # Auto-copy to clipboard
-        gmuse msg --model claude-3-opus  # Use specific model
-        gmuse msg --temperature 0.3      # Lower temperature for more deterministic output
-        gmuse msg --max-tokens 200       # Limit response length
-        gmuse msg --include-branch       # Include branch context
-        gmuse msg --dry-run              # Preview prompt without calling LLM
+    This command is the raw stdout-only primitive intended for scripting and
+    completion use. It prints the generated message to stdout on success.
     """
     try:
-        # Load and merge configuration
+        # Load and merge configuration (clipboard/copy is intentionally not part of the raw path)
         config = _load_config(
             model=model,
-            copy=copy,
             format=format,
             history_depth=history_depth,
             temperature=temperature,
@@ -289,9 +271,162 @@ def msg(
         # Output message to stdout
         typer.echo(result.message)
 
-        # Copy to clipboard if requested
-        if config.get("copy_to_clipboard"):
-            _copy_to_clipboard(result.message)
+    except ConfigError as e:
+        _error_exit(str(e), code=1)
+
+    except NotAGitRepositoryError as e:
+        _error_exit(
+            str(e),
+            hint="Run this command inside a git repository.\nTo initialize a new repository: git init",
+            code=1,
+        )
+
+    except NoStagedChangesError as e:
+        _error_exit(
+            str(e),
+            hint="Stage your changes first:\n  git add <files>",
+            code=1,
+        )
+
+    except LLMError as e:
+        _error_exit(str(e), code=2)
+
+    except InvalidMessageError as e:
+        _error_exit(
+            f"Generated message is invalid: {e}",
+            hint="This is likely a temporary issue. Try again.",
+            code=2,
+        )
+
+    except KeyboardInterrupt:
+        typer.echo("\n\nInterrupted by user", err=True)
+        raise typer.Exit(code=130)
+
+
+# Backwards-compatible deprecated alias
+@app.command(name="msg")
+def msg(
+    hint: Optional[str] = typer.Option(
+        None,
+        "--hint",
+        help="(Deprecated) Additional guidance for message generation",
+    ),
+    copy: bool = typer.Option(
+        False,
+        "--copy",
+        "-c",
+        help="(Deprecated) Copy generated message to clipboard",
+    ),
+    model: Optional[str] = typer.Option(None, "--model", "-m"),
+    format: Optional[str] = typer.Option(None, "--format", "-f"),
+    history_depth: Optional[int] = typer.Option(None, "--history-depth"),
+    temperature: Optional[float] = typer.Option(None, "--temperature"),
+    max_tokens: Optional[int] = typer.Option(None, "--max-tokens"),
+    max_diff_bytes: Optional[int] = typer.Option(None, "--max-diff-bytes"),
+    include_branch: bool = typer.Option(False, "--include-branch"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+) -> None:
+    """Deprecated alias for `gmuse generate`.
+
+    Emits deprecation guidance to stderr while preserving stdout output so scripts
+    that rely on `gmuse msg` continue to function.
+    """
+    # Emit deprecation notice on stderr
+    typer.secho(
+        "'gmuse msg' is deprecated and will be removed in a future release. Use 'gmuse generate' instead.",
+        fg=typer.colors.YELLOW,
+        err=True,
+    )
+
+    if copy:
+        # Legacy clipboard behavior is deprecated — fail with migration guidance
+        _error_exit(
+            "Clipboard-based output is deprecated and not supported by 'gmuse generate'.",
+            hint=(
+                "To get a message for scripting: use 'gmuse generate'.\n"
+                "To copy to clipboard manually: gmuse generate | pbcopy (mac) or xclip -sel clip (linux)"
+            ),
+            code=2,
+        )
+
+    # Forward to generate
+    # Note: Typer won't let us simply call generate(**kwargs) due to CLI decoration; call programmatically
+    ctx = typer.Context(app)
+    ctx.exit = lambda *args, **kwargs: None  # prevent Typer from exiting the process
+    # Build arguments and call the underlying function
+    generate(
+        hint=hint,
+        model=model,
+        format=format,
+        history_depth=history_depth,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        max_diff_bytes=max_diff_bytes,
+        include_branch=include_branch,
+        dry_run=dry_run,
+    )
+
+
+@app.command(name="commit")
+def commit(
+    hint: Optional[str] = typer.Option(
+        None,
+        "--hint",
+        help="Hint for message generation",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Non-interactive: generate and commit immediately",
+    ),
+    model: Optional[str] = typer.Option(None, "--model", "-m"),
+    format: Optional[str] = typer.Option(None, "--format", "-f"),
+    history_depth: Optional[int] = typer.Option(None, "--history-depth"),
+    temperature: Optional[float] = typer.Option(None, "--temperature"),
+    max_tokens: Optional[int] = typer.Option(None, "--max-tokens"),
+    max_diff_bytes: Optional[int] = typer.Option(None, "--max-diff-bytes"),
+    include_branch: bool = typer.Option(False, "--include-branch"),
+) -> None:
+    """Interactive commit workflow: generate, review, and create a git commit.
+
+    In interactive terminals this opens a small review loop allowing accept/edit/regenerate/abort.
+    In non-interactive scripts, use --yes to generate and commit immediately.
+    """
+    try:
+        # Load config and gather context
+        config = _load_config(
+            model=model,
+            format=format,
+            history_depth=history_depth,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            max_diff_bytes=max_diff_bytes,
+            include_branch=include_branch,
+        )
+
+        context = gather_context(
+            history_depth=config.get("history_depth", 5),
+            max_diff_bytes=config.get("max_diff_bytes", 20000),
+            include_branch=config.get("include_branch", False),
+            branch_max_length=config.get("branch_max_length", 60),
+        )
+
+        # Non-interactive guard
+        if not yes and (not sys.stdin.isatty() or not sys.stdout.isatty()):
+            _error_exit(
+                "gmuse commit requires an interactive terminal. Use --yes for non-interactive commits or 'gmuse generate' for scripting.",
+                code=2,
+            )
+
+        # Delegate to commit session
+        run_commit_session(
+            config=config,
+            hint=hint,
+            context=context,
+            generate_fn=lambda cfg, h, ctx: generate_message(config=cfg, hint=h, context=ctx),
+            non_interactive=yes,
+        )
 
     except ConfigError as e:
         _error_exit(str(e), code=1)

--- a/src/gmuse/cli/main.py
+++ b/src/gmuse/cli/main.py
@@ -476,7 +476,9 @@ def commit(
         )
 
     except subprocess.CalledProcessError as e:
-        output = (e.stderr or e.stdout or str(e)).strip()
+        output = (
+            e.stderr or e.stdout or "git commit exited without creating a commit"
+        ).strip()
         _error_exit(f"Git commit failed: {output}", code=1)
 
     except KeyboardInterrupt:

--- a/src/gmuse/cli/main.py
+++ b/src/gmuse/cli/main.py
@@ -20,6 +20,7 @@ Example:
 """
 
 import os
+import subprocess
 import sys
 from typing import Any, Optional
 
@@ -331,6 +332,27 @@ def msg(
     Emits deprecation guidance to stderr while preserving stdout output so scripts
     that rely on `gmuse msg` continue to function.
     """
+    if isinstance(hint, typer.models.OptionInfo):
+        hint = None
+    if isinstance(copy, typer.models.OptionInfo):
+        copy = False
+    if isinstance(model, typer.models.OptionInfo):
+        model = None
+    if isinstance(format, typer.models.OptionInfo):
+        format = None
+    if isinstance(history_depth, typer.models.OptionInfo):
+        history_depth = None
+    if isinstance(temperature, typer.models.OptionInfo):
+        temperature = None
+    if isinstance(max_tokens, typer.models.OptionInfo):
+        max_tokens = None
+    if isinstance(max_diff_bytes, typer.models.OptionInfo):
+        max_diff_bytes = None
+    if isinstance(include_branch, typer.models.OptionInfo):
+        include_branch = False
+    if isinstance(dry_run, typer.models.OptionInfo):
+        dry_run = False
+
     # Emit deprecation notice on stderr
     typer.secho(
         "'gmuse msg' is deprecated and will be removed in a future release. Use 'gmuse generate' instead.",
@@ -349,11 +371,7 @@ def msg(
             code=2,
         )
 
-    # Forward to generate
-    # Note: Typer won't let us simply call generate(**kwargs) due to CLI decoration; call programmatically
-    ctx = typer.Context(app)
-    ctx.exit = lambda *args, **kwargs: None  # prevent Typer from exiting the process
-    # Build arguments and call the underlying function
+    # Forward to generate while preserving the legacy command's stdout contract.
     generate(
         hint=hint,
         model=model,
@@ -394,6 +412,12 @@ def commit(
     In non-interactive scripts, use --yes to generate and commit immediately.
     """
     try:
+        if not yes and (not sys.stdin.isatty() or not sys.stdout.isatty()):
+            _error_exit(
+                "gmuse commit requires an interactive terminal. Use --yes for non-interactive commits or 'gmuse generate' for scripting.",
+                code=2,
+            )
+
         # Load config and gather context
         config = _load_config(
             model=model,
@@ -412,19 +436,14 @@ def commit(
             branch_max_length=config.get("branch_max_length", 60),
         )
 
-        # Non-interactive guard
-        if not yes and (not sys.stdin.isatty() or not sys.stdout.isatty()):
-            _error_exit(
-                "gmuse commit requires an interactive terminal. Use --yes for non-interactive commits or 'gmuse generate' for scripting.",
-                code=2,
-            )
-
         # Delegate to commit session
         run_commit_session(
             config=config,
             hint=hint,
             context=context,
-            generate_fn=lambda cfg, h, ctx: generate_message(config=cfg, hint=h, context=ctx),
+            generate_fn=lambda cfg, h, ctx: generate_message(
+                config=cfg, hint=h, context=ctx
+            ),
             non_interactive=yes,
         )
 
@@ -454,6 +473,10 @@ def commit(
             hint="This is likely a temporary issue. Try again.",
             code=2,
         )
+
+    except subprocess.CalledProcessError as e:
+        output = (e.stderr or e.stdout or str(e)).strip()
+        _error_exit(f"Git commit failed: {output}", code=1)
 
     except KeyboardInterrupt:
         typer.echo("\n\nInterrupted by user", err=True)

--- a/src/gmuse/cli/main.py
+++ b/src/gmuse/cli/main.py
@@ -16,7 +16,7 @@ Commands:
 
 Example:
     >>> # From command line:
-    >>> # gmuse msg --hint "security fix" --copy
+    >>> # gmuse commit --hint "security fix"
 """
 
 import os
@@ -113,13 +113,14 @@ def main(
 
     Generate commit messages from staged changes using AI.
 
-    Use 'gmuse msg' to create a commit message from your staged changes.
+    Use 'gmuse commit' to generate, review, and create a commit from staged changes.
+    Use 'gmuse generate' when you need stdout-only output for scripts.
 
     Examples:
-        gmuse msg                           # Generate message
-        gmuse msg --hint "breaking change"  # With hint
-        gmuse msg --format conventional     # Conventional commits
-        gmuse msg --copy                    # Copy to clipboard
+        gmuse commit                        # Review and commit
+        gmuse commit --yes                  # Generate and commit immediately
+        gmuse generate                      # Print message only
+        gmuse generate --format conventional  # Conventional commits
         gmuse info                          # Show configuration
 
     For more information, visit: https://gmuse.readthedocs.io

--- a/src/gmuse/git.py
+++ b/src/gmuse/git.py
@@ -734,3 +734,58 @@ def get_current_branch(max_length: int = 60) -> Optional[BranchInfo]:
     except subprocess.TimeoutExpired:
         logger.warning("Git branch command timed out")
         return None
+
+
+# -----------------------------------------------------------------------------
+# Commit / Editor helpers
+# -----------------------------------------------------------------------------
+
+
+def commit_with_message(message: str) -> None:
+    """Create a git commit using the provided message.
+
+    Writes the message to a temporary file and calls `git commit --file=<file>`
+    which is portable across platforms and preserves multiline messages.
+
+    Raises:
+        subprocess.CalledProcessError: If git commit exits non-zero.
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as f:
+        f.write(message)
+        tmp_path = f.name
+
+    try:
+        _run_git("commit", "--file", tmp_path, timeout=_GIT_TIMEOUT_LONG)
+    finally:
+        try:
+            Path(tmp_path).unlink()
+        except Exception:
+            pass
+
+
+def open_editor_with_message(message: str) -> None:
+    """Open the user's editor with the message prefilled and run the commit.
+
+    Uses `git commit --edit -F <file>` so the editor is launched with the draft
+    message and git performs the commit after the editor exits. Caller should be
+    prepared to handle non-zero exit codes if the commit was aborted.
+
+    Raises:
+        subprocess.CalledProcessError: If git commit exits non-zero.
+    """
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as f:
+        f.write(message)
+        tmp_path = f.name
+
+    try:
+        # Use --edit so the user's configured editor is launched with the prefilled message
+        _run_git("commit", "--edit", "-F", tmp_path, timeout=_GIT_TIMEOUT_LONG)
+    finally:
+        try:
+            Path(tmp_path).unlink()
+        except Exception:
+            pass

--- a/src/gmuse/git.py
+++ b/src/gmuse/git.py
@@ -25,6 +25,7 @@ import re
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Final, Optional
 
@@ -146,6 +147,13 @@ class BranchInfo:
     branch_type: Optional[str]
     branch_summary: Optional[str]
     is_default: bool = False
+
+
+class CommitOutcome(Enum):
+    """Outcome from an interactive git commit operation."""
+
+    CREATED = "created"
+    ABORTED = "aborted"
 
 
 # -----------------------------------------------------------------------------
@@ -765,7 +773,7 @@ def commit_with_message(message: str) -> None:
             pass
 
 
-def open_editor_with_message(message: str) -> None:
+def open_editor_with_message(message: str) -> CommitOutcome:
     """Open the user's editor with the message prefilled and run the commit.
 
     Uses `git commit --edit -F <file>` so the editor is launched with the draft
@@ -774,7 +782,8 @@ def open_editor_with_message(message: str) -> None:
     interactive editors can control the terminal.
 
     Raises:
-        subprocess.CalledProcessError: If git commit exits non-zero.
+        subprocess.CalledProcessError: If git commit exits non-zero for reasons
+            other than an intentionally blank edited message.
     """
     import tempfile
 
@@ -787,6 +796,11 @@ def open_editor_with_message(message: str) -> None:
             ["git", "commit", "--edit", "-F", tmp_path],
             check=True,
         )
+        return CommitOutcome.CREATED
+    except subprocess.CalledProcessError:
+        if Path(tmp_path).read_text(encoding="utf-8").strip() == "":
+            return CommitOutcome.ABORTED
+        raise
     finally:
         try:
             Path(tmp_path).unlink()

--- a/src/gmuse/git.py
+++ b/src/gmuse/git.py
@@ -769,8 +769,9 @@ def open_editor_with_message(message: str) -> None:
     """Open the user's editor with the message prefilled and run the commit.
 
     Uses `git commit --edit -F <file>` so the editor is launched with the draft
-    message and git performs the commit after the editor exits. Caller should be
-    prepared to handle non-zero exit codes if the commit was aborted.
+    message and git performs the commit after the editor exits. Unlike the raw
+    git helpers, this intentionally inherits stdio and avoids a short timeout so
+    interactive editors can control the terminal.
 
     Raises:
         subprocess.CalledProcessError: If git commit exits non-zero.
@@ -782,8 +783,10 @@ def open_editor_with_message(message: str) -> None:
         tmp_path = f.name
 
     try:
-        # Use --edit so the user's configured editor is launched with the prefilled message
-        _run_git("commit", "--edit", "-F", tmp_path, timeout=_GIT_TIMEOUT_LONG)
+        subprocess.run(
+            ["git", "commit", "--edit", "-F", tmp_path],
+            check=True,
+        )
     finally:
         try:
             Path(tmp_path).unlink()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -333,11 +333,12 @@ class TestUserStory3:
                     finally:
                         os.chdir(old_cwd)
 
-                    assert result.exit_code == 0
-                    assert "Add feature function" in result.stdout
-                    # Verify clipboard copy was called
-                    mock_pyperclip.copy.assert_called_once_with("Add feature function")
-                    assert "Copied to clipboard" in result.stderr
+                    assert result.exit_code == 2
+                    assert result.stdout == ""
+                    assert "clipboard" in result.stderr.lower()
+                    assert "gmuse generate" in result.stderr
+                    mock_client.generate.assert_not_called()
+                    mock_pyperclip.copy.assert_not_called()
 
     def test_copy_flag_pyperclip_not_installed(
         self, git_repo_with_history: Path
@@ -372,14 +373,11 @@ class TestUserStory3:
                     finally:
                         os.chdir(old_cwd)
 
-                    # Should still succeed and output the message
-                    assert result.exit_code == 0
-                    assert "Add feature function" in result.stdout
-                    # Should show warning about pyperclip
-                    assert (
-                        "pyperclip" in result.stderr.lower()
-                        or "clipboard" in result.stderr.lower()
-                    )
+                    assert result.exit_code == 2
+                    assert result.stdout == ""
+                    assert "clipboard" in result.stderr.lower()
+                    assert "gmuse generate" in result.stderr
+                    mock_client.generate.assert_not_called()
 
 
 class TestUserStory4:

--- a/tests/integration/test_cli_generate_commit.py
+++ b/tests/integration/test_cli_generate_commit.py
@@ -1,0 +1,93 @@
+"""Integration tests for the generate/commit CLI workflow."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from gmuse.cli.main import app
+
+runner = CliRunner()
+
+
+def _create_history(repo: Path) -> None:
+    readme = repo / "README.md"
+    readme.write_text("# Test Project\n")
+    subprocess.run(
+        ["git", "add", "README.md"], cwd=repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _stage_file(repo: Path, filename: str, content: str) -> None:
+    file_path = repo / filename
+    file_path.write_text(content)
+    subprocess.run(["git", "add", filename], cwd=repo, check=True, capture_output=True)
+
+
+def test_generate_is_stdout_only(git_repo: Path, monkeypatch) -> None:
+    """generate should print only the draft message on success."""
+    _create_history(git_repo)
+    _stage_file(git_repo, "feature.py", "def hello():\n    return 'hi'\n")
+    monkeypatch.chdir(git_repo)
+
+    with mock.patch("gmuse.commit.LLMClient") as mock_client_class:
+        mock_client = mock.Mock()
+        mock_client.generate.return_value = "feat: add hello"
+        mock_client_class.return_value = mock_client
+
+        result = runner.invoke(app, ["generate"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "feat: add hello\n"
+    assert result.stderr == ""
+
+
+def test_msg_warns_but_keeps_stdout_compatible(git_repo: Path, monkeypatch) -> None:
+    """msg should preserve stdout output for legacy scripts while warning on stderr."""
+    _create_history(git_repo)
+    _stage_file(git_repo, "feature.py", "def hello():\n    return 'hi'\n")
+    monkeypatch.chdir(git_repo)
+
+    with mock.patch("gmuse.commit.LLMClient") as mock_client_class:
+        mock_client = mock.Mock()
+        mock_client.generate.return_value = "feat: add hello"
+        mock_client_class.return_value = mock_client
+
+        result = runner.invoke(app, ["msg"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "feat: add hello\n"
+    assert "deprecated" in result.stderr.lower()
+
+
+def test_commit_yes_creates_git_commit(git_repo: Path, monkeypatch) -> None:
+    """commit --yes should create a real git commit with the generated subject."""
+    _create_history(git_repo)
+    _stage_file(git_repo, "feature.py", "def hello():\n    return 'hi'\n")
+    monkeypatch.chdir(git_repo)
+
+    with mock.patch("gmuse.commit.LLMClient") as mock_client_class:
+        mock_client = mock.Mock()
+        mock_client.generate.return_value = "feat: add hello"
+        mock_client_class.return_value = mock_client
+
+        result = runner.invoke(app, ["commit", "--yes"])
+
+    assert result.exit_code == 0
+    last_subject = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert last_subject == "feat: add hello"

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest import mock
 
 import pytest
@@ -74,7 +75,7 @@ def test_edit_opens_editor(
 ) -> None:
     """Edit should hand the draft off to the git editor flow."""
     generate_fn = mock.Mock(return_value=_result("feat: add tests"))
-    editor_mock = mock.Mock()
+    editor_mock = mock.Mock(return_value=commit_session.CommitOutcome.CREATED)
 
     monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
     monkeypatch.setattr("builtins.input", lambda _: "e")
@@ -83,7 +84,7 @@ def test_edit_opens_editor(
 
     editor_mock.assert_called_once_with("feat: add tests")
     captured = capsys.readouterr()
-    assert "Editor exited" in captured.out
+    assert "Commit created" in captured.out
 
 
 def test_eof_aborts_without_commit(
@@ -107,7 +108,7 @@ def test_eof_aborts_without_commit(
 
 
 def test_regenerate_replaces_draft_before_accept(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Regenerate should fetch a new draft and commit that one when accepted."""
     generate_fn = mock.Mock(
@@ -123,23 +124,25 @@ def test_regenerate_replaces_draft_before_accept(
 
     assert generate_fn.call_count == 2
     commit_mock.assert_called_once_with("feat: regenerated draft")
+    captured = capsys.readouterr()
+    assert "Regenerating commit message" in captured.out
 
 
-def test_abort_exits_without_commit(
+def test_quit_exits_without_commit(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Abort should leave the repository untouched."""
+    """Quit should leave the repository untouched."""
     generate_fn = mock.Mock(return_value=_result("feat: add tests"))
     commit_mock = mock.Mock()
 
     monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
-    monkeypatch.setattr("builtins.input", lambda _: "x")
+    monkeypatch.setattr("builtins.input", lambda _: "q")
 
     commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
 
     commit_mock.assert_not_called()
     captured = capsys.readouterr()
-    assert "Aborted" in captured.err
+    assert "Commit aborted" in captured.out
 
 
 def test_invalid_choice_reprompts(
@@ -147,11 +150,72 @@ def test_invalid_choice_reprompts(
 ) -> None:
     """Invalid actions should show guidance and continue prompting."""
     generate_fn = mock.Mock(return_value=_result("feat: add tests"))
-    choices = iter(["nope", "x"])
+    choices = iter(["nope", "q"])
 
     monkeypatch.setattr("builtins.input", lambda _: next(choices))
 
     commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
 
     captured = capsys.readouterr()
-    assert "Unrecognized action" in captured.out
+    assert "Invalid choice" in captured.out
+    assert "a, e, r, or q" in captured.out
+    assert captured.out.count("Draft commit message") == 1
+
+
+def test_x_is_invalid_and_reprompts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The visible quit action is q, not x."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    choices = iter(["x", "q"])
+
+    monkeypatch.setattr("builtins.input", lambda _: next(choices))
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    captured = capsys.readouterr()
+    assert "Invalid choice" in captured.out
+    assert "Commit aborted" in captured.out
+
+
+def test_edit_blank_message_aborts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Blank edited messages should be treated as intentional aborts."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock(return_value=commit_session.CommitOutcome.ABORTED)
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "e")
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    captured = capsys.readouterr()
+    assert "Commit aborted" in captured.out
+    assert "Error:" not in captured.err
+
+
+def test_accept_failure_prints_git_output_without_error_wrapper(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Interactive git failures should preserve git output without subprocess text."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    commit_mock = mock.Mock(
+        side_effect=subprocess.CalledProcessError(
+            1,
+            ["git", "commit"],
+            stderr="nothing to commit",
+        )
+    )
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "a")
+
+    with pytest.raises(commit_session.typer.Exit) as exc_info:
+        commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.exit_code == 1
+    assert "nothing to commit" in captured.err
+    assert "Error:" not in captured.err
+    assert "Command '[" not in captured.err

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -87,6 +87,54 @@ def test_edit_opens_editor(
     assert "Commit created" in captured.out
 
 
+def test_edit_first_opens_editor_without_prompting(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The --edit path should hand the first generated draft to the editor."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock(return_value=commit_session.CommitOutcome.CREATED)
+    input_mock = mock.Mock()
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+    monkeypatch.setattr("builtins.input", input_mock)
+
+    commit_session.run_commit_session(
+        {},
+        None,
+        _fake_context(),
+        generate_fn,
+        edit_first=True,
+    )
+
+    editor_mock.assert_called_once_with("feat: add tests")
+    input_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Commit created" in captured.out
+    assert "Draft commit message" not in captured.out
+
+
+def test_edit_first_blank_message_aborts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A blank message in edit-first mode should be a clean non-commit outcome."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock(return_value=commit_session.CommitOutcome.ABORTED)
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+
+    commit_session.run_commit_session(
+        {},
+        None,
+        _fake_context(),
+        generate_fn,
+        edit_first=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "Commit aborted" in captured.out
+    assert "Error:" not in captured.err
+
+
 def test_eof_aborts_without_commit(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -86,6 +86,26 @@ def test_edit_opens_editor(
     assert "Editor exited" in captured.out
 
 
+def test_eof_aborts_without_commit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Closed stdin should abort without creating a commit."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    commit_mock = mock.Mock()
+
+    def _raise_eof(_: str) -> str:
+        raise EOFError
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+    monkeypatch.setattr("builtins.input", _raise_eof)
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    commit_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Input closed" in captured.err
+
+
 def test_regenerate_replaces_draft_before_accept(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -135,6 +135,36 @@ def test_edit_first_blank_message_aborts(
     assert "Error:" not in captured.err
 
 
+def test_edit_first_failure_prints_git_output_without_error_wrapper(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Edit-first git failures should preserve git output."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock(
+        side_effect=subprocess.CalledProcessError(
+            1,
+            ["git", "commit", "--edit"],
+            stderr="hook failed",
+        )
+    )
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+
+    with pytest.raises(commit_session.typer.Exit) as exc_info:
+        commit_session.run_commit_session(
+            {},
+            None,
+            _fake_context(),
+            generate_fn,
+            edit_first=True,
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.exit_code == 1
+    assert "hook failed" in captured.err
+    assert "Error:" not in captured.err
+
+
 def test_eof_aborts_without_commit(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -241,6 +271,30 @@ def test_edit_blank_message_aborts(
     captured = capsys.readouterr()
     assert "Commit aborted" in captured.out
     assert "Error:" not in captured.err
+
+
+def test_edit_failure_without_output_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Editor failures without git output should use the friendly fallback."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock(
+        side_effect=subprocess.CalledProcessError(
+            1,
+            ["git", "commit", "--edit"],
+        )
+    )
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "e")
+
+    with pytest.raises(commit_session.typer.Exit) as exc_info:
+        commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    captured = capsys.readouterr()
+    assert exc_info.value.exit_code == 1
+    assert "Commit failed" in captured.err
+    assert "Command '[" not in captured.err
 
 
 def test_accept_failure_prints_git_output_without_error_wrapper(

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -1,0 +1,137 @@
+"""Unit tests for the interactive commit session."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from gmuse import commit
+from gmuse.cli import commit_session
+
+
+def _fake_context() -> commit.GenerationContext:
+    fake_diff = mock.Mock(
+        size_bytes=10,
+        files_changed=["file.py"],
+        lines_added=1,
+        lines_removed=0,
+        raw_diff="diff --git a/file.py b/file.py\n",
+        hash="abc123",
+        truncated=False,
+    )
+    return commit.GenerationContext(
+        diff=fake_diff,
+        history=None,
+        repo_instructions=None,
+        diff_was_truncated=False,
+    )
+
+
+def _result(message: str) -> commit.GenerationResult:
+    return commit.GenerationResult(message=message, context=_fake_context())
+
+
+def test_non_interactive_commits_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The --yes path should commit the first generated draft without prompting."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    commit_mock = mock.Mock()
+    context = _fake_context()
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+
+    commit_session.run_commit_session(
+        config={"format": "freeform"},
+        hint="focus tests",
+        context=context,
+        generate_fn=generate_fn,
+        non_interactive=True,
+    )
+
+    generate_fn.assert_called_once_with({"format": "freeform"}, "focus tests", context)
+    commit_mock.assert_called_once_with("feat: add tests")
+
+
+def test_accept_commits_current_draft(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Accept should commit the current draft and exit."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    commit_mock = mock.Mock()
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "a")
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    commit_mock.assert_called_once_with("feat: add tests")
+    captured = capsys.readouterr()
+    assert "Commit created" in captured.out
+
+
+def test_edit_opens_editor(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Edit should hand the draft off to the git editor flow."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    editor_mock = mock.Mock()
+
+    monkeypatch.setattr(commit_session, "open_editor_with_message", editor_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "e")
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    editor_mock.assert_called_once_with("feat: add tests")
+    captured = capsys.readouterr()
+    assert "Editor exited" in captured.out
+
+
+def test_regenerate_replaces_draft_before_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regenerate should fetch a new draft and commit that one when accepted."""
+    generate_fn = mock.Mock(
+        side_effect=[_result("feat: first draft"), _result("feat: regenerated draft")]
+    )
+    commit_mock = mock.Mock()
+    choices = iter(["r", "a"])
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+    monkeypatch.setattr("builtins.input", lambda _: next(choices))
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    assert generate_fn.call_count == 2
+    commit_mock.assert_called_once_with("feat: regenerated draft")
+
+
+def test_abort_exits_without_commit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Abort should leave the repository untouched."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    commit_mock = mock.Mock()
+
+    monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
+    monkeypatch.setattr("builtins.input", lambda _: "q")
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    commit_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "Aborted" in captured.err
+
+
+def test_invalid_choice_reprompts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Invalid actions should show guidance and continue prompting."""
+    generate_fn = mock.Mock(return_value=_result("feat: add tests"))
+    choices = iter(["nope", "q"])
+
+    monkeypatch.setattr("builtins.input", lambda _: next(choices))
+
+    commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
+
+    captured = capsys.readouterr()
+    assert "Unrecognized action" in captured.out

--- a/tests/unit/test_cli_commit_session.py
+++ b/tests/unit/test_cli_commit_session.py
@@ -113,7 +113,7 @@ def test_abort_exits_without_commit(
     commit_mock = mock.Mock()
 
     monkeypatch.setattr(commit_session, "commit_with_message", commit_mock)
-    monkeypatch.setattr("builtins.input", lambda _: "q")
+    monkeypatch.setattr("builtins.input", lambda _: "x")
 
     commit_session.run_commit_session({}, None, _fake_context(), generate_fn)
 
@@ -127,7 +127,7 @@ def test_invalid_choice_reprompts(
 ) -> None:
     """Invalid actions should show guidance and continue prompting."""
     generate_fn = mock.Mock(return_value=_result("feat: add tests"))
-    choices = iter(["nope", "q"])
+    choices = iter(["nope", "x"])
 
     monkeypatch.setattr("builtins.input", lambda _: next(choices))
 

--- a/tests/unit/test_cli_msg_dry_run.py
+++ b/tests/unit/test_cli_msg_dry_run.py
@@ -243,34 +243,21 @@ class TestDryRunFlagCombinations:
     @patch("gmuse.cli.main.gather_context")
     @patch("gmuse.cli.main.build_prompt")
     @patch("gmuse.cli.main._copy_to_clipboard")
-    def test_copy_does_not_copy_during_dry_run(
+    def test_copy_fails_before_dry_run(
         self,
         mock_copy: MagicMock,
         mock_build_prompt: MagicMock,
         mock_gather_context: MagicMock,
     ) -> None:
-        """--copy should NOT copy anything when --dry-run is used."""
-        mock_diff: StagedDiff = StagedDiff(
-            raw_diff="d",
-            files_changed=["c.py"],
-            lines_added=1,
-            lines_removed=0,
-            hash="h",
-            size_bytes=10,
-        )
-        mock_context: GenerationContext = GenerationContext(
-            diff=mock_diff,
-            history=None,
-            repo_instructions=None,
-            diff_was_truncated=False,
-        )
-        mock_gather_context.return_value = mock_context
-        mock_build_prompt.return_value = ("sys", "usr")
-
+        """--copy should fail with migration guidance before dry-run work."""
         result = runner.invoke(app, ["msg", "--dry-run", "--copy"])
 
-        assert result.exit_code == 0
+        assert result.exit_code == 2
+        assert "clipboard" in result.stderr.lower()
+        assert "gmuse generate" in result.stderr
         mock_copy.assert_not_called()
+        mock_build_prompt.assert_not_called()
+        mock_gather_context.assert_not_called()
 
     @patch("gmuse.cli.main.gather_context")
     @patch("gmuse.cli.main.build_prompt")

--- a/tests/unit/test_cli_redesign.py
+++ b/tests/unit/test_cli_redesign.py
@@ -99,8 +99,7 @@ def test_commit_without_yes_fails_before_loading_config(monkeypatch) -> None:
 
     monkeypatch.setattr(main, "_load_config", load_config)
     monkeypatch.setattr(main, "gather_context", gather_context)
-    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: False)
-    monkeypatch.setattr(main.sys.stdout, "isatty", lambda: False)
+    monkeypatch.setattr(main, "_is_interactive_terminal", lambda: False)
 
     result = runner.invoke(main.app, ["commit"])
 
@@ -134,6 +133,47 @@ def test_commit_yes_delegates_to_commit_session(monkeypatch) -> None:
     assert session_mock.call_args.kwargs["hint"] == "ship it"
     assert session_mock.call_args.kwargs["context"] is context
     assert session_mock.call_args.kwargs["non_interactive"] is True
+    assert session_mock.call_args.kwargs["edit_first"] is False
+
+
+def test_commit_edit_delegates_to_commit_session(monkeypatch) -> None:
+    """commit --edit should request edit-first mode after generating a draft."""
+    session_mock = mock.Mock()
+    context = _fake_context()
+
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: context)
+    monkeypatch.setattr(main, "run_commit_session", session_mock)
+    monkeypatch.setattr(main, "_is_interactive_terminal", lambda: True)
+
+    result = runner.invoke(main.app, ["commit", "--edit", "--hint", "ship it"])
+
+    assert result.exit_code == 0
+    session_mock.assert_called_once()
+    assert session_mock.call_args.kwargs["hint"] == "ship it"
+    assert session_mock.call_args.kwargs["context"] is context
+    assert session_mock.call_args.kwargs["non_interactive"] is False
+    assert session_mock.call_args.kwargs["edit_first"] is True
+
+
+def test_commit_yes_and_edit_are_mutually_exclusive(monkeypatch) -> None:
+    """commit should reject conflicting automatic commit modes before setup."""
+    load_config = mock.Mock()
+    gather_context = mock.Mock()
+
+    monkeypatch.setattr(main, "_load_config", load_config)
+    monkeypatch.setattr(main, "gather_context", gather_context)
+
+    result = runner.invoke(main.app, ["commit", "--yes", "--edit"])
+
+    assert result.exit_code == 2
+    assert "Cannot use --yes and --edit together" in result.stderr
+    load_config.assert_not_called()
+    gather_context.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli_redesign.py
+++ b/tests/unit/test_cli_redesign.py
@@ -109,6 +109,28 @@ def test_commit_without_yes_fails_before_loading_config(monkeypatch) -> None:
     gather_context.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("stdin_isatty", "stdout_isatty", "expected"),
+    [
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
+        (False, False, False),
+    ],
+)
+def test_is_interactive_terminal_requires_stdin_and_stdout_ttys(
+    monkeypatch: pytest.MonkeyPatch,
+    stdin_isatty: bool,
+    stdout_isatty: bool,
+    expected: bool,
+) -> None:
+    """Interactive commit mode should require both input and output TTYs."""
+    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: stdin_isatty)
+    monkeypatch.setattr(main.sys.stdout, "isatty", lambda: stdout_isatty)
+
+    assert main._is_interactive_terminal() is expected
+
+
 def test_commit_yes_delegates_to_commit_session(monkeypatch) -> None:
     """commit --yes should pass the resolved context into the session helper."""
     session_mock = mock.Mock()

--- a/tests/unit/test_cli_redesign.py
+++ b/tests/unit/test_cli_redesign.py
@@ -1,0 +1,127 @@
+"""Unit tests for the generate/commit CLI redesign."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from gmuse import commit
+from gmuse.cli import main
+
+runner = CliRunner()
+
+
+def _fake_context() -> commit.GenerationContext:
+    fake_diff = mock.Mock(
+        size_bytes=10,
+        files_changed=["file.py"],
+        lines_added=1,
+        lines_removed=0,
+        raw_diff="diff --git a/file.py b/file.py\n",
+        hash="abc123",
+        truncated=False,
+    )
+    return commit.GenerationContext(
+        diff=fake_diff,
+        history=None,
+        repo_instructions=None,
+        diff_was_truncated=False,
+    )
+
+
+def _result(message: str) -> commit.GenerationResult:
+    return commit.GenerationResult(message=message, context=_fake_context())
+
+
+def test_generate_prints_message_only(monkeypatch) -> None:
+    """generate should emit only the generated message on stdout."""
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: _fake_context())
+    monkeypatch.setattr(
+        main, "generate_message", lambda **kwargs: _result("feat: add api")
+    )
+
+    result = runner.invoke(main.app, ["generate"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "feat: add api\n"
+    assert result.stderr == ""
+
+
+def test_msg_emits_deprecation_notice_and_preserves_stdout(monkeypatch) -> None:
+    """msg should keep stdout-compatible output while warning on stderr."""
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: _fake_context())
+    monkeypatch.setattr(
+        main, "generate_message", lambda **kwargs: _result("feat: add api")
+    )
+
+    result = runner.invoke(main.app, ["msg"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "feat: add api\n"
+    assert "deprecated" in result.stderr.lower()
+    assert "gmuse generate" in result.stderr
+
+
+def test_msg_copy_fails_with_migration_guidance() -> None:
+    """Legacy clipboard mode should fail with actionable migration guidance."""
+    result = runner.invoke(main.app, ["msg", "--copy"])
+
+    assert result.exit_code == 2
+    assert "deprecated" in result.stderr.lower()
+    assert "clipboard" in result.stderr.lower()
+    assert "gmuse generate" in result.stderr
+
+
+def test_commit_without_yes_fails_before_loading_config(monkeypatch) -> None:
+    """Non-interactive commit should fail fast without touching git or config."""
+    load_config = mock.Mock()
+    gather_context = mock.Mock()
+
+    monkeypatch.setattr(main, "_load_config", load_config)
+    monkeypatch.setattr(main, "gather_context", gather_context)
+    monkeypatch.setattr(main.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(main.sys.stdout, "isatty", lambda: False)
+
+    result = runner.invoke(main.app, ["commit"])
+
+    assert result.exit_code == 2
+    assert "interactive terminal" in result.stderr
+    load_config.assert_not_called()
+    gather_context.assert_not_called()
+
+
+def test_commit_yes_delegates_to_commit_session(monkeypatch) -> None:
+    """commit --yes should pass the resolved context into the session helper."""
+    session_mock = mock.Mock()
+    context = _fake_context()
+
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: context)
+    monkeypatch.setattr(main, "run_commit_session", session_mock)
+
+    result = runner.invoke(main.app, ["commit", "--yes", "--hint", "ship it"])
+
+    assert result.exit_code == 0
+    session_mock.assert_called_once()
+    assert session_mock.call_args.kwargs["config"] == {
+        "format": "freeform",
+        "history_depth": 5,
+    }
+    assert session_mock.call_args.kwargs["hint"] == "ship it"
+    assert session_mock.call_args.kwargs["context"] is context
+    assert session_mock.call_args.kwargs["non_interactive"] is True

--- a/tests/unit/test_cli_redesign.py
+++ b/tests/unit/test_cli_redesign.py
@@ -198,3 +198,31 @@ def test_commit_keyboard_interrupt_exits_130(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result.exit_code == 130
     assert "Interrupted by user" in result.stderr
+
+
+def test_commit_git_failure_without_output_uses_friendly_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive git failures should not expose raw subprocess details."""
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: _fake_context())
+    monkeypatch.setattr(
+        main,
+        "run_commit_session",
+        mock.Mock(
+            side_effect=subprocess.CalledProcessError(
+                1,
+                ["git", "commit", "--edit", "-F", "/tmp/message"],
+            )
+        ),
+    )
+
+    result = runner.invoke(main.app, ["commit", "--yes"])
+
+    assert result.exit_code == 1
+    assert "git commit exited without creating a commit" in result.stderr
+    assert "Command '[" not in result.stderr

--- a/tests/unit/test_cli_redesign.py
+++ b/tests/unit/test_cli_redesign.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest import mock
 
+import pytest
 from typer.testing import CliRunner
 
 from gmuse import commit
 from gmuse.cli import main
+from gmuse.exceptions import (
+    ConfigError,
+    InvalidMessageError,
+    LLMError,
+    NoStagedChangesError,
+    NotAGitRepositoryError,
+)
 
 runner = CliRunner()
 
@@ -125,3 +134,67 @@ def test_commit_yes_delegates_to_commit_session(monkeypatch) -> None:
     assert session_mock.call_args.kwargs["hint"] == "ship it"
     assert session_mock.call_args.kwargs["context"] is context
     assert session_mock.call_args.kwargs["non_interactive"] is True
+
+
+@pytest.mark.parametrize(
+    ("exc", "exit_code", "expected"),
+    [
+        (ConfigError("bad config"), 1, "bad config"),
+        (NotAGitRepositoryError("no repo"), 1, "git init"),
+        (NoStagedChangesError("no staged changes"), 1, "git add"),
+        (LLMError("provider failed"), 2, "provider failed"),
+        (InvalidMessageError("too long"), 2, "Try again"),
+        (
+            subprocess.CalledProcessError(
+                1,
+                "git commit",
+                stderr="nothing to commit",
+            ),
+            1,
+            "Git commit failed: nothing to commit",
+        ),
+    ],
+)
+def test_commit_error_branches_exit_with_expected_messages(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: Exception,
+    exit_code: int,
+    expected: str,
+) -> None:
+    """commit --yes should translate expected failures into CLI errors."""
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: _fake_context())
+    monkeypatch.setattr(
+        main,
+        "run_commit_session",
+        mock.Mock(side_effect=exc),
+    )
+
+    result = runner.invoke(main.app, ["commit", "--yes"])
+
+    assert result.exit_code == exit_code
+    assert expected in result.stderr
+
+
+def test_commit_keyboard_interrupt_exits_130(monkeypatch: pytest.MonkeyPatch) -> None:
+    """commit should preserve the standard interrupted exit code."""
+    monkeypatch.setattr(
+        main,
+        "_load_config",
+        lambda **kwargs: {"format": "freeform", "history_depth": 5},
+    )
+    monkeypatch.setattr(main, "gather_context", lambda **kwargs: _fake_context())
+    monkeypatch.setattr(
+        main,
+        "run_commit_session",
+        mock.Mock(side_effect=KeyboardInterrupt()),
+    )
+
+    result = runner.invoke(main.app, ["commit", "--yes"])
+
+    assert result.exit_code == 130
+    assert "Interrupted by user" in result.stderr

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -10,6 +10,7 @@ import pytest
 
 from gmuse.exceptions import NoStagedChangesError, NotAGitRepositoryError
 from gmuse.git import (
+    CommitOutcome,
     StagedDiff,
     _parse_commit_line,
     commit_with_message,
@@ -409,15 +410,28 @@ class TestCommitEditorHelpers:
 
         with mock.patch("subprocess.run", run_mock):
             with mock.patch("gmuse.git._run_git") as run_git_mock:
-                open_editor_with_message("feat: add editor flow")
+                outcome = open_editor_with_message("feat: add editor flow")
 
         run_mock.assert_called_once()
         args, kwargs = run_mock.call_args
         assert args[0][:4] == ["git", "commit", "--edit", "-F"]
         temp_path = Path(args[0][4])
         assert kwargs == {"check": True}
+        assert outcome is CommitOutcome.CREATED
         assert not temp_path.exists()
         run_git_mock.assert_not_called()
+
+    def test_open_editor_with_message_blank_message_aborts(self) -> None:
+        """An intentionally blank edited message should not surface as failure."""
+
+        def _blank_message_and_fail(args: list[str], **_: object) -> None:
+            Path(args[4]).write_text("", encoding="utf-8")
+            raise subprocess.CalledProcessError(1, args)
+
+        with mock.patch("subprocess.run", side_effect=_blank_message_and_fail):
+            outcome = open_editor_with_message("feat: add editor flow")
+
+        assert outcome is CommitOutcome.ABORTED
 
     def test_open_editor_with_message_ignores_cleanup_failure(self) -> None:
         """Editor helper should not mask git success with cleanup errors."""

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -433,6 +433,19 @@ class TestCommitEditorHelpers:
 
         assert outcome is CommitOutcome.ABORTED
 
+    def test_open_editor_with_message_nonblank_failure_reraises(self) -> None:
+        """A failed edit with message content should preserve the git failure."""
+
+        def _keep_message_and_fail(args: list[str], **_: object) -> None:
+            Path(args[4]).write_text("feat: keep message", encoding="utf-8")
+            raise subprocess.CalledProcessError(1, args, stderr="hook failed")
+
+        with mock.patch("subprocess.run", side_effect=_keep_message_and_fail):
+            with pytest.raises(subprocess.CalledProcessError) as exc_info:
+                open_editor_with_message("feat: add editor flow")
+
+        assert exc_info.value.stderr == "hook failed"
+
     def test_open_editor_with_message_ignores_cleanup_failure(self) -> None:
         """Editor helper should not mask git success with cleanup errors."""
         run_mock = mock.Mock()

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -17,6 +17,7 @@ from gmuse.git import (
     get_staged_diff,
     is_git_repository,
     load_repository_instructions,
+    open_editor_with_message,
     truncate_diff,
 )
 
@@ -376,3 +377,25 @@ class TestLoadRepositoryInstructions:
                     assert instructions.exists is False
                 finally:
                     gmuse_file.chmod(0o644)  # Restore permissions for cleanup
+
+
+class TestCommitEditorHelpers:
+    """Tests for git commit editor helpers."""
+
+    def test_open_editor_with_message_inherits_stdio_and_removes_temp_file(
+        self,
+    ) -> None:
+        """Editor handoff should avoid captured git wrapper and short timeouts."""
+        run_mock = mock.Mock()
+
+        with mock.patch("subprocess.run", run_mock):
+            with mock.patch("gmuse.git._run_git") as run_git_mock:
+                open_editor_with_message("feat: add editor flow")
+
+        run_mock.assert_called_once()
+        args, kwargs = run_mock.call_args
+        assert args[0][:4] == ["git", "commit", "--edit", "-F"]
+        temp_path = Path(args[0][4])
+        assert kwargs == {"check": True}
+        assert not temp_path.exists()
+        run_git_mock.assert_not_called()

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -12,6 +12,7 @@ from gmuse.exceptions import NoStagedChangesError, NotAGitRepositoryError
 from gmuse.git import (
     StagedDiff,
     _parse_commit_line,
+    commit_with_message,
     get_commit_history,
     get_repo_root,
     get_staged_diff,
@@ -382,6 +383,24 @@ class TestLoadRepositoryInstructions:
 class TestCommitEditorHelpers:
     """Tests for git commit editor helpers."""
 
+    def test_commit_with_message_uses_temp_file_and_ignores_cleanup_failure(
+        self,
+    ) -> None:
+        """Commit helper should still succeed if temp-file cleanup fails."""
+        run_git_mock = mock.Mock()
+
+        with mock.patch("gmuse.git._run_git", run_git_mock):
+            with mock.patch("pathlib.Path.unlink", side_effect=OSError("locked")):
+                commit_with_message("feat: add commit flow")
+
+        run_git_mock.assert_called_once()
+        args, kwargs = run_git_mock.call_args
+        temp_path = Path(args[2])
+        assert args[:2] == ("commit", "--file")
+        assert temp_path.exists()
+        assert kwargs["timeout"] > 0
+        temp_path.unlink()
+
     def test_open_editor_with_message_inherits_stdio_and_removes_temp_file(
         self,
     ) -> None:
@@ -399,3 +418,13 @@ class TestCommitEditorHelpers:
         assert kwargs == {"check": True}
         assert not temp_path.exists()
         run_git_mock.assert_not_called()
+
+    def test_open_editor_with_message_ignores_cleanup_failure(self) -> None:
+        """Editor helper should not mask git success with cleanup errors."""
+        run_mock = mock.Mock()
+
+        with mock.patch("subprocess.run", run_mock):
+            with mock.patch("pathlib.Path.unlink", side_effect=OSError("locked")):
+                open_editor_with_message("feat: add editor flow")
+
+        run_mock.assert_called_once()


### PR DESCRIPTION
## Summary

Redesigns the CLI commit workflow around explicit `generate` and `commit` commands. The new flow separates message generation from committing, adds commit-session orchestration, and teaches the git helpers to support the terminal editor path used by `gmuse commit`.

## What changed

- Adds `gmuse generate` for producing commit messages from staged changes without creating a commit.
- Adds `gmuse commit` for generating, reviewing, and applying a commit message in one guided workflow.
- Keeps dry-run and abort behavior aligned with the redesigned command prompts.
- Updates CLI examples and the 008 feature specification docs for the redesigned UX.
- Extends integration and unit coverage for the new CLI commands, commit session behavior, and git helper functions.

## Compatibility

This is a breaking CLI UX change because commit-message generation is now organized around the explicit `generate` and `commit` commands instead of the previous command shape.

## Validation

- Added unit tests for commit-session orchestration and CLI redesign behavior.
- Added integration coverage for `generate` and `commit` command flows.
