### PR TITLE
ci: set workflow permissions

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 


### PR DESCRIPTION
## Summary
- Add explicit read-only workflow permissions for GitHub Actions
- Address code-scanning alerts for missing workflow permissions in run-checks.yaml

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run pre-commit run check-yaml --files .github/workflows/run-checks.yaml
- pre-commit during commit