### PR TITLE
fix: pin pre-commit Node version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  node: 22.14.0
+
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
Pre-commit currently selects the installed Node/npm version automatically. npm 12 rejects the installer flag used by the cspell hook, preventing commits before any files are checked. Pin Node hooks to Node 22.14.0, whose bundled npm remains compatible with this pre-commit setup.\n\nValidation: the full applicable pre-commit suite passes, and cspell passes against README.md.